### PR TITLE
fix: deduplicate streaming output and bypass Windows cmd.exe length limit

### DIFF
--- a/src/lib/cli-stream-parser.ts
+++ b/src/lib/cli-stream-parser.ts
@@ -1,25 +1,51 @@
 /**
- * Parse a line from Cursor CLI stream-json output.
- * Calls onText for each text chunk and onDone when the stream completes.
+ * Create a stateful stream parser for Cursor CLI stream-json output.
+ *
+ * The CLI emits individual assistant delta chunks and then a final assistant
+ * message containing the full accumulated text. We track what we've already
+ * emitted so the final duplicate is skipped.
  */
-export function parseCliStreamLine(
-  line: string,
+export function createStreamParser(
   onText: (text: string) => void,
   onDone: () => void,
-): void {
-  try {
-    const obj = JSON.parse(line) as {
-      type?: string;
-      subtype?: string;
-      message?: { content?: Array<{ type?: string; text?: string }> };
-    };
-    if (obj.type === "assistant" && obj.message?.content) {
-      for (const part of obj.message.content) {
-        if (part.type === "text" && part.text) onText(part.text);
+): (line: string) => void {
+  let accumulated = "";
+  let done = false;
+
+  return (line: string) => {
+    if (done) return;
+    try {
+      const obj = JSON.parse(line) as {
+        type?: string;
+        subtype?: string;
+        message?: { content?: Array<{ type?: string; text?: string }> };
+      };
+
+      if (obj.type === "assistant" && obj.message?.content) {
+        const text = obj.message.content
+          .filter((p) => p.type === "text" && p.text)
+          .map((p) => p.text!)
+          .join("");
+        if (!text) return;
+
+        if (text === accumulated) return;
+
+        if (text.startsWith(accumulated) && accumulated.length > 0) {
+          const delta = text.slice(accumulated.length);
+          if (delta) onText(delta);
+          accumulated = text;
+        } else {
+          onText(text);
+          accumulated += text;
+        }
       }
+
+      if (obj.type === "result" && obj.subtype === "success") {
+        done = true;
+        onDone();
+      }
+    } catch {
+      /* ignore parse errors for non-JSON lines */
     }
-    if (obj.type === "result" && obj.subtype === "success") onDone();
-  } catch {
-    /* ignore parse errors for non-JSON lines */
-  }
+  };
 }

--- a/src/lib/handlers/anthropic-messages.ts
+++ b/src/lib/handlers/anthropic-messages.ts
@@ -5,7 +5,7 @@ import type { AnthropicMessagesRequest } from "../anthropic.js";
 import { buildPromptFromAnthropicMessages } from "../anthropic.js";
 import { buildAgentCmdArgs } from "../agent-cmd-args.js";
 import { runAgentStream, runAgentSync } from "../agent-runner.js";
-import { parseCliStreamLine } from "../cli-stream-parser.js";
+import { createStreamParser } from "../cli-stream-parser.js";
 import type { BridgeConfig } from "../config.js";
 import { json, writeSseHeaders } from "../http.js";
 import { resolveToCursorModel } from "../model-map.js";
@@ -117,37 +117,35 @@ export async function handleAnthropicMessages(
     });
 
     let accumulated = "";
+    const parseLine = createStreamParser(
+      (text) => {
+        accumulated += text;
+        writeEvent({
+          type: "content_block_delta",
+          index: 0,
+          delta: { type: "text_delta", text },
+        });
+      },
+      () => {
+        logTrafficResponse(
+          config.verbose,
+          model ?? cursorModel,
+          accumulated,
+          true,
+        );
+        writeEvent({ type: "content_block_stop", index: 0 });
+        writeEvent({
+          type: "message_delta",
+          delta: { stop_reason: "end_turn" },
+        });
+        writeEvent({ type: "message_stop" });
+      },
+    );
     runAgentStream(
       config,
       workspaceDir,
       cmdArgs,
-      (line) => {
-        parseCliStreamLine(
-          line,
-          (text) => {
-            accumulated += text;
-            writeEvent({
-              type: "content_block_delta",
-              index: 0,
-              delta: { type: "text_delta", text },
-            });
-          },
-          () => {
-            logTrafficResponse(
-              config.verbose,
-              model ?? cursorModel,
-              accumulated,
-              true,
-            );
-            writeEvent({ type: "content_block_stop", index: 0 });
-            writeEvent({
-              type: "message_delta",
-              delta: { stop_reason: "end_turn" },
-            });
-            writeEvent({ type: "message_stop" });
-          },
-        );
-      },
+      parseLine,
       tempDir,
     )
       .then(({ code, stderr: stderrOut }) => {

--- a/src/lib/handlers/chat-completions.ts
+++ b/src/lib/handlers/chat-completions.ts
@@ -4,7 +4,7 @@ import * as http from "node:http";
 import type { BridgeConfig } from "../config.js";
 import { buildAgentCmdArgs } from "../agent-cmd-args.js";
 import { runAgentStream, runAgentSync } from "../agent-runner.js";
-import { parseCliStreamLine } from "../cli-stream-parser.js";
+import { createStreamParser } from "../cli-stream-parser.js";
 import { json, writeSseHeaders } from "../http.js";
 import { resolveToCursorModel } from "../model-map.js";
 import {
@@ -81,47 +81,45 @@ export async function handleChatCompletions(
     writeSseHeaders(res);
 
     let accumulated = "";
+    const parseLine = createStreamParser(
+      (text) => {
+        accumulated += text;
+        res.write(
+          `data: ${JSON.stringify({
+            id,
+            object: "chat.completion.chunk",
+            created,
+            model,
+            choices: [
+              { index: 0, delta: { content: text }, finish_reason: null },
+            ],
+          })}\n\n`,
+        );
+      },
+      () => {
+        logTrafficResponse(
+          config.verbose,
+          model ?? cursorModel,
+          accumulated,
+          true,
+        );
+        res.write(
+          `data: ${JSON.stringify({
+            id,
+            object: "chat.completion.chunk",
+            created,
+            model,
+            choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
+          })}\n\n`,
+        );
+        res.write("data: [DONE]\n\n");
+      },
+    );
     runAgentStream(
       config,
       workspaceDir,
       cmdArgs,
-      (line) => {
-        parseCliStreamLine(
-          line,
-          (text) => {
-            accumulated += text;
-            res.write(
-              `data: ${JSON.stringify({
-                id,
-                object: "chat.completion.chunk",
-                created,
-                model,
-                choices: [
-                  { index: 0, delta: { content: text }, finish_reason: null },
-                ],
-              })}\n\n`,
-            );
-          },
-          () => {
-            logTrafficResponse(
-              config.verbose,
-              model ?? cursorModel,
-              accumulated,
-              true,
-            );
-            res.write(
-              `data: ${JSON.stringify({
-                id,
-                object: "chat.completion.chunk",
-                created,
-                model,
-                choices: [{ index: 0, delta: {}, finish_reason: "stop" }],
-              })}\n\n`,
-            );
-            res.write("data: [DONE]\n\n");
-          },
-        );
-      },
+      parseLine,
       tempDir,
     )
       .then(({ code, stderr: stderrOut }) => {

--- a/src/lib/process.ts
+++ b/src/lib/process.ts
@@ -15,17 +15,42 @@ export type RunStreamingOptions = RunOptions & {
   onLine: (line: string) => void;
 };
 
+function spawnChild(cmd: string, args: string[], cwd?: string) {
+  if (process.platform === "win32") {
+    const nodeBin = process.env.CURSOR_AGENT_NODE;
+    const agentScript = process.env.CURSOR_AGENT_SCRIPT;
+    if (nodeBin && agentScript) {
+      return spawn(nodeBin, [agentScript, ...args], {
+        cwd,
+        env: { ...process.env, CURSOR_INVOKED_AS: "agent.cmd" },
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    }
+    if (/\.cmd$/i.test(cmd)) {
+      const quotedArgs = args.map((a) => (a.includes(" ") ? `"${a}"` : a)).join(" ");
+      const cmdLine = `""${cmd}" ${quotedArgs}"`;
+      return spawn(process.env.COMSPEC || "cmd.exe", ["/d", "/s", "/c", cmdLine], {
+        cwd,
+        env: process.env,
+        stdio: ["ignore", "pipe", "pipe"],
+        windowsVerbatimArguments: true,
+      });
+    }
+  }
+  return spawn(cmd, args, {
+    cwd,
+    env: process.env,
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
 export function runStreaming(
   cmd: string,
   args: string[],
   opts: RunStreamingOptions,
 ): Promise<{ code: number; stderr: string }> {
   return new Promise((resolve, reject) => {
-    const child = spawn(cmd, args, {
-      cwd: opts.cwd,
-      env: process.env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+    const child = spawnChild(cmd, args, opts.cwd);
 
     const timeoutMs = opts.timeoutMs;
     const timeout =
@@ -38,11 +63,11 @@ export function runStreaming(
     let stderr = "";
     let lineBuffer = "";
 
-    child.stderr.setEncoding("utf8");
-    child.stderr.on("data", (c) => (stderr += c));
+    child.stderr!.setEncoding("utf8");
+    child.stderr!.on("data", (c) => (stderr += c));
 
-    child.stdout.setEncoding("utf8");
-    child.stdout.on("data", (chunk: string) => {
+    child.stdout!.setEncoding("utf8");
+    child.stdout!.on("data", (chunk: string) => {
       lineBuffer += chunk;
       const lines = lineBuffer.split("\n");
       lineBuffer = lines.pop() ?? "";
@@ -74,11 +99,7 @@ export function runStreaming(
 
 export function run(cmd: string, args: string[], opts: RunOptions = {}): Promise<RunResult> {
   return new Promise((resolve, reject) => {
-    const child = spawn(cmd, args, {
-      cwd: opts.cwd,
-      env: process.env,
-      stdio: ["ignore", "pipe", "pipe"],
-    });
+    const child = spawnChild(cmd, args, opts.cwd);
 
     const timeoutMs = opts.timeoutMs;
     const timeout =
@@ -91,10 +112,10 @@ export function run(cmd: string, args: string[], opts: RunOptions = {}): Promise
     let stdout = "";
     let stderr = "";
 
-    child.stdout.setEncoding("utf8");
-    child.stderr.setEncoding("utf8");
-    child.stdout.on("data", (c) => (stdout += c));
-    child.stderr.on("data", (c) => (stderr += c));
+    child.stdout!.setEncoding("utf8");
+    child.stderr!.setEncoding("utf8");
+    child.stdout!.on("data", (c) => (stdout += c));
+    child.stderr!.on("data", (c) => (stderr += c));
 
     child.on("error", (err: NodeJS.ErrnoException) => {
       if (timeout) clearTimeout(timeout);


### PR DESCRIPTION
## Summary

Fixes two bugs discovered when using cursor-api-proxy on Windows with streaming mode:

- **Duplicate streaming output (cross-platform)**: The Cursor CLI in `--stream-partial-output --output-format stream-json` mode emits individual delta chunks, then a final assistant message containing the full accumulated text. The stateless `parseCliStreamLine` treated every assistant message as new content, causing responses to appear twice. Replaced with a stateful `createStreamParser` that tracks emitted text and skips duplicates.

- **"The command line is too long" (Windows)**: When a client sends long prompts (e.g. GitHub Copilot's ~10KB system prompt), `cmd.exe /s /c` rejects the command due to its ~8192 char limit. Added `CURSOR_AGENT_NODE` / `CURSOR_AGENT_SCRIPT` env var support so `spawnChild` can call `node.exe` directly via `CreateProcess` (~32KB limit), bypassing `cmd.exe`.

## Changes

| File | What |
|------|------|
| `src/lib/cli-stream-parser.ts` | New `createStreamParser` with accumulated-text dedup |
| `src/lib/process.ts` | `spawnChild` direct `node.exe` spawn path for Windows |
| `src/lib/handlers/chat-completions.ts` | Use `createStreamParser` |
| `src/lib/handlers/anthropic-messages.ts` | Use `createStreamParser` |

## How to use the Windows bypass

Set two env vars before starting the proxy:

```batch
set "CURSOR_AGENT_NODE=C:\path\to\cursor\bin\node.exe"
set "CURSOR_AGENT_SCRIPT=C:\path\to\cursor\bin\index.js"
```

When both are set, `spawnChild` calls `node.exe` directly instead of routing through `cmd.exe`. Falls back to the existing `cmd.exe /s /c` behavior if unset.

## Test plan

- [x] Streaming request returns each delta exactly once (no duplicate final chunk)
- [x] Non-streaming request returns correct single response
- [x] Long prompts (>8KB) work on Windows with env vars set
- [x] Existing behavior preserved on non-Windows / when env vars not set
