### PR TITLE
fix: pass through "auto" model identifier to Cursor API

### DIFF
--- a/src/lib/resolve-model.ts
+++ b/src/lib/resolve-model.ts
@@ -9,14 +9,16 @@ export function resolveModel(
   lastRequestedModelRef: { current?: string },
   config: BridgeConfig,
 ): string {
-  const explicitModel =
-    requested && requested !== "auto" ? requested : undefined;
+  const isAuto = requested === "auto";
+  const explicitModel = requested && !isAuto ? requested : undefined;
   if (explicitModel) lastRequestedModelRef.current = explicitModel;
+
+  // "auto" is a valid Cursor model identifier — pass it through directly
+  if (isAuto) return "auto";
 
   return (
     explicitModel ??
     (config.strictModel ? lastRequestedModelRef.current : undefined) ??
-    requested ??
     lastRequestedModelRef.current ??
     config.defaultModel
   );


### PR DESCRIPTION
## Summary

When clients send `model: "auto"` (e.g. Claude Code CLI), the proxy now forwards it directly to Cursor CLI instead of treating it as unspecified and falling back to the last-used or default model. Cursor natively supports `"auto"` as a valid model identifier.

## Root Cause

In `resolve-model.ts`, `"auto"` was explicitly excluded from being treated as an explicit model:

\`\`\`ts
// Before
const explicitModel = requested && requested !== "auto" ? requested : undefined;
\`\`\`

This caused `"auto"` to be dropped and replaced by `lastRequestedModelRef.current` or `config.defaultModel`.

## Fix

`"auto"` is now detected and returned immediately, bypassing the fallback logic. It is intentionally not recorded in `lastRequestedModelRef` to avoid polluting model memory for subsequent requests.

Closes #7

Made with [Cursor](https://cursor.com)