### PR TITLE
fix(acp): set_config_option value field, skip default model, rename auto sentinel

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -374,7 +374,7 @@ export function createCursorProxyClient(options: CursorProxyClientOptions = {}) 
         choices?: Array<{ message?: { content?: string } }>;
         error?: { message?: string };
       }>("/v1/chat/completions", {
-        model: params.model ?? "auto",
+        model: params.model ?? "default",
         messages: params.messages,
         stream: false,
       });

--- a/src/lib/__tests__/fake-acp-server.mjs
+++ b/src/lib/__tests__/fake-acp-server.mjs
@@ -1,18 +1,63 @@
 /**
  * Minimal fake ACP server for integration tests.
  * Reads JSON-RPC from stdin, responds to initialize, authenticate, session/new, session/prompt.
+ *
+ * Env:
+ * - FAKE_ACP_SCENARIO: unset | empty_models | dup_names | fail_set_config
+ *
+ * Emits to stderr for assertions: __FAKE_ACP_SET_CONFIG__:<json>\n
  */
 import { createInterface } from "node:readline";
+
+const scenario = process.env.FAKE_ACP_SCENARIO || "";
+
+function sessionNewResult() {
+  if (scenario === "empty_models") {
+    return { sessionId: "sess-1", models: { availableModels: [] } };
+  }
+  if (scenario === "dup_names") {
+    return {
+      sessionId: "sess-1",
+      models: {
+        availableModels: [
+          { modelId: "first-id[]", name: "gpt-4" },
+          { modelId: "second-id[]", name: "gpt-4" },
+        ],
+      },
+    };
+  }
+  return {
+    sessionId: "sess-1",
+    models: {
+      availableModels: [{ modelId: "gpt-4[fast=false]", name: "gpt-4" }],
+    },
+  };
+}
 
 const rl = createInterface({ input: process.stdin });
 rl.on("line", (line) => {
   try {
     const msg = JSON.parse(line);
     if (msg.id != null && msg.method) {
+      if (msg.method === "session/set_config_option") {
+        process.stderr.write(`__FAKE_ACP_SET_CONFIG__:${JSON.stringify(msg.params)}\n`);
+      }
+
+      if (msg.method === "session/set_config_option" && scenario === "fail_set_config") {
+        process.stdout.write(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            id: msg.id,
+            error: { code: -32603, message: "Internal error" },
+          }) + "\n",
+        );
+        return;
+      }
+
       let result = {};
       if (msg.method === "initialize") result = { protocolVersion: 1 };
       else if (msg.method === "authenticate") result = {};
-      else if (msg.method === "session/new") result = { sessionId: "sess-1" };
+      else if (msg.method === "session/new") result = sessionNewResult();
       else if (msg.method === "session/set_config_option") result = {};
       else if (msg.method === "session/prompt") {
         result = {};

--- a/src/lib/acp-client.test.ts
+++ b/src/lib/acp-client.test.ts
@@ -118,12 +118,12 @@ describe("runAcpSync", () => {
     });
   });
 
-  it("skips session/set_config_option when model is auto with no catalog match", async () => {
+  it("skips session/set_config_option when model is default with no catalog match", async () => {
     const result = await runAcpSync(node, [fakeServerPath], "hi", {
       cwd,
       timeoutMs: 5000,
       skipAuthenticate: true,
-      model: "auto",
+      model: "default",
     });
     expect(result.code).toBe(0);
     expect(result.stdout).toContain("Hello from fake ACP");

--- a/src/lib/acp-client.test.ts
+++ b/src/lib/acp-client.test.ts
@@ -1,10 +1,54 @@
 import { join } from "node:path";
 import { describe, expect, it } from "vitest";
-import { runAcpStream, runAcpSync } from "./acp-client.js";
+import {
+  resolveAcpModelConfigValue,
+  runAcpStream,
+  runAcpSync,
+} from "./acp-client.js";
 
 const node = process.execPath;
 const cwd = process.cwd();
 const fakeServerPath = join(cwd, "src", "lib", "__tests__", "fake-acp-server.mjs");
+
+function parseLastSetConfig(stderr: string): Record<string, unknown> | null {
+  const lines = stderr.split("\n").filter((l) => l.startsWith("__FAKE_ACP_SET_CONFIG__:"));
+  if (lines.length === 0) return null;
+  const last = lines[lines.length - 1];
+  return JSON.parse(last.slice("__FAKE_ACP_SET_CONFIG__:".length)) as Record<string, unknown>;
+}
+
+describe("resolveAcpModelConfigValue", () => {
+  it("returns display name when catalog is missing", () => {
+    expect(resolveAcpModelConfigValue("gpt-4", undefined)).toBe("gpt-4");
+  });
+
+  it("returns display name when catalog is empty", () => {
+    expect(resolveAcpModelConfigValue("gpt-4", [])).toBe("gpt-4");
+  });
+
+  it("maps name to modelId when matched", () => {
+    expect(
+      resolveAcpModelConfigValue("gpt-4", [
+        { modelId: "gpt-4[fast=false]", name: "gpt-4" },
+      ]),
+    ).toBe("gpt-4[fast=false]");
+  });
+
+  it("returns pass-through when name not in catalog", () => {
+    expect(
+      resolveAcpModelConfigValue("unknown", [{ modelId: "x[]", name: "gpt-4" }]),
+    ).toBe("unknown");
+  });
+
+  it("uses first match when duplicate names", () => {
+    expect(
+      resolveAcpModelConfigValue("gpt-4", [
+        { modelId: "first[]", name: "gpt-4" },
+        { modelId: "second[]", name: "gpt-4" },
+      ]),
+    ).toBe("first[]");
+  });
+});
 
 describe("runAcpSync", () => {
   it("returns stdout content from session/update agent_message_chunk", async () => {
@@ -40,7 +84,7 @@ describe("runAcpSync", () => {
     expect(result.stdout).toBeTruthy();
   });
 
-  it("applies session/set_config_option when model is set", async () => {
+  it("sends session/set_config_option with configId and resolved value", async () => {
     const result = await runAcpSync(node, [fakeServerPath], "hi", {
       cwd,
       timeoutMs: 5000,
@@ -49,6 +93,65 @@ describe("runAcpSync", () => {
     });
     expect(result.code).toBe(0);
     expect(result.stdout).toContain("Hello from fake ACP");
+    const cfg = parseLastSetConfig(result.stderr);
+    expect(cfg).toEqual({
+      sessionId: "sess-1",
+      configId: "model",
+      value: "gpt-4[fast=false]",
+    });
+  });
+
+  it("passes through model when availableModels is empty", async () => {
+    const result = await runAcpSync(node, [fakeServerPath], "hi", {
+      cwd,
+      timeoutMs: 5000,
+      skipAuthenticate: true,
+      model: "gpt-4",
+      env: { FAKE_ACP_SCENARIO: "empty_models" },
+    });
+    expect(result.code).toBe(0);
+    const cfg = parseLastSetConfig(result.stderr);
+    expect(cfg).toEqual({
+      sessionId: "sess-1",
+      configId: "model",
+      value: "gpt-4",
+    });
+  });
+
+  it("skips session/set_config_option when model is auto with no catalog match", async () => {
+    const result = await runAcpSync(node, [fakeServerPath], "hi", {
+      cwd,
+      timeoutMs: 5000,
+      skipAuthenticate: true,
+      model: "auto",
+    });
+    expect(result.code).toBe(0);
+    expect(result.stdout).toContain("Hello from fake ACP");
+    expect(parseLastSetConfig(result.stderr)).toBeNull();
+  });
+
+  it("uses first catalog modelId when duplicate display names", async () => {
+    const result = await runAcpSync(node, [fakeServerPath], "hi", {
+      cwd,
+      timeoutMs: 5000,
+      skipAuthenticate: true,
+      model: "gpt-4",
+      env: { FAKE_ACP_SCENARIO: "dup_names" },
+    });
+    expect(result.code).toBe(0);
+    const cfg = parseLastSetConfig(result.stderr);
+    expect(cfg?.value).toBe("first-id[]");
+  });
+
+  it("fails when session/set_config_option returns error", async () => {
+    const result = await runAcpSync(node, [fakeServerPath], "hi", {
+      cwd,
+      timeoutMs: 5000,
+      skipAuthenticate: true,
+      model: "gpt-4",
+      env: { FAKE_ACP_SCENARIO: "fail_set_config" },
+    });
+    expect(result.code).toBe(1);
   });
 });
 
@@ -68,5 +171,35 @@ describe("runAcpStream", () => {
     );
     expect(result.code).toBe(0);
     expect(chunks.join("")).toContain("Hello from fake ACP");
+  });
+
+  it("sends session/set_config_option with configId when model is set", async () => {
+    const chunks: string[] = [];
+    const result = await runAcpStream(node, [fakeServerPath], "stream", {
+      cwd,
+      timeoutMs: 5000,
+      skipAuthenticate: true,
+      model: "gpt-4",
+    }, (t) => chunks.push(t));
+    expect(result.code).toBe(0);
+    expect(chunks.join("")).toContain("Hello from fake ACP");
+    const cfg = parseLastSetConfig(result.stderr);
+    expect(cfg).toEqual({
+      sessionId: "sess-1",
+      configId: "model",
+      value: "gpt-4[fast=false]",
+    });
+  });
+
+  it("fails when session/set_config_option returns error (stream)", async () => {
+    const chunks: string[] = [];
+    const result = await runAcpStream(node, [fakeServerPath], "x", {
+      cwd,
+      timeoutMs: 5000,
+      skipAuthenticate: true,
+      model: "gpt-4",
+      env: { FAKE_ACP_SCENARIO: "fail_set_config" },
+    }, (t) => chunks.push(t));
+    expect(result.code).toBe(1);
   });
 });

--- a/src/lib/acp-client.ts
+++ b/src/lib/acp-client.ts
@@ -437,7 +437,7 @@ export function runAcpSync(
             opts.model,
             sessionResult.models?.availableModels,
           );
-          if (resolvedModelId !== "auto" && resolvedModelId !== "default[]") {
+          if (resolvedModelId !== "default" && resolvedModelId !== "default[]") {
             debugAcp("ACP step: session/set_config_option (model)");
             await sendRequest(
               child.stdin,
@@ -640,7 +640,7 @@ export function runAcpStream(
             opts.model,
             sessionResult.models?.availableModels,
           );
-          if (resolvedModelId !== "auto" && resolvedModelId !== "default[]") {
+          if (resolvedModelId !== "default" && resolvedModelId !== "default[]") {
             debugAcp("ACP step: session/set_config_option (model)");
             await sendRequest(
               child.stdin,

--- a/src/lib/acp-client.ts
+++ b/src/lib/acp-client.ts
@@ -89,6 +89,17 @@ type AcpParsedMsg = {
   error?: { message?: string };
 };
 
+/** Normalise CRLF / stray CR so JSON-RPC lines parse on Windows (avoids silent hangs). */
+function parseAcpStdoutLine(line: string): AcpParsedMsg | null {
+  const t = line.replace(/\r$/, "").trim();
+  if (!t) return null;
+  try {
+    return JSON.parse(t) as AcpParsedMsg;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Handle ACP server→client notifications (session/update chunks, permissions, cursor/*).
  * Returns true if the message was consumed as a notification.
@@ -182,6 +193,30 @@ function handleAcpNotification(
   }
 
   return false;
+}
+
+export type AcpAvailableModel = { modelId: string; name: string };
+
+/**
+ * Map OpenAI-style display name to Cursor ACP `modelId` (e.g. `composer-2` → `composer-2[fast=true]`).
+ * If `availableModels` is missing or empty, returns `displayName` unchanged.
+ * If the list is non-empty but no row matches `name`, logs via debug and returns `displayName` (pass-through).
+ * Duplicate `name` entries: first match wins.
+ */
+export function resolveAcpModelConfigValue(
+  displayName: string,
+  availableModels: AcpAvailableModel[] | undefined,
+): string {
+  if (!availableModels?.length) return displayName;
+  const hit = availableModels.find((m) => m.name === displayName);
+  if (!hit) {
+    debugAcp(
+      "ACP model: no catalog match for display name %j; using value as-is",
+      displayName,
+    );
+    return displayName;
+  }
+  return hit.modelId;
 }
 
 function sendRequest(
@@ -311,12 +346,14 @@ export function runAcpSync(
         if (opts.rawDebug) {
           debugAcp("ACP raw: %s", line);
         }
-        const msg = JSON.parse(line) as AcpParsedMsg;
+        const msg = parseAcpStdoutLine(line);
+        if (!msg) return;
 
         if (msg.id != null && (msg.result !== undefined || msg.error !== undefined)) {
-          const waiter = pending.get(msg.id);
+          const reqId = typeof msg.id === "number" ? msg.id : Number(msg.id);
+          const waiter = Number.isFinite(reqId) ? pending.get(reqId) : undefined;
           if (waiter) {
-            pending.delete(msg.id);
+            pending.delete(reqId);
             if (msg.error) {
               waiter.reject(new Error(msg.error.message ?? "ACP error"));
             } else {
@@ -334,7 +371,7 @@ export function runAcpSync(
           },
         });
       } catch {
-        /* ignore parse errors */
+        /* ignore notification handler errors */
       }
     });
 
@@ -385,7 +422,10 @@ export function runAcpSync(
           { cwd: opts.cwd, mcpServers: [] },
           pending,
           requestTimeoutMs,
-        )) as { sessionId?: string };
+        )) as {
+          sessionId?: string;
+          models?: { availableModels?: AcpAvailableModel[] };
+        };
         const sessionId = sessionResult?.sessionId;
         if (!sessionId) {
           finish(1);
@@ -393,15 +433,25 @@ export function runAcpSync(
         }
 
         if (opts.model) {
-          debugAcp("ACP step: session/set_config_option (model)");
-          await sendRequest(
-            child.stdin,
-            nextId,
-            "session/set_config_option",
-            { sessionId, option: "model", value: opts.model },
-            pending,
-            requestTimeoutMs,
+          const resolvedModelId = resolveAcpModelConfigValue(
+            opts.model,
+            sessionResult.models?.availableModels,
           );
+          if (resolvedModelId !== "auto" && resolvedModelId !== "default[]") {
+            debugAcp("ACP step: session/set_config_option (model)");
+            await sendRequest(
+              child.stdin,
+              nextId,
+              "session/set_config_option",
+              { sessionId, configId: "model", value: resolvedModelId },
+              pending,
+              requestTimeoutMs,
+            );
+          } else {
+            debugAcp(
+              "ACP step: session/set_config_option (model) — skipped, using session default",
+            );
+          }
         }
 
         debugAcp("ACP step: session/prompt");
@@ -416,7 +466,6 @@ export function runAcpSync(
       } catch {
         if (timeout) clearTimeout(timeout);
         if (!resolved) {
-          resolved = true;
           finish(1);
         }
       }
@@ -502,12 +551,14 @@ export function runAcpStream(
         if (opts.rawDebug) {
           debugAcp("ACP raw: %s", line);
         }
-        const msg = JSON.parse(line) as AcpParsedMsg;
+        const msg = parseAcpStdoutLine(line);
+        if (!msg) return;
 
         if (msg.id != null && (msg.result !== undefined || msg.error !== undefined)) {
-          const waiter = pending.get(msg.id);
+          const reqId = typeof msg.id === "number" ? msg.id : Number(msg.id);
+          const waiter = Number.isFinite(reqId) ? pending.get(reqId) : undefined;
           if (waiter) {
-            pending.delete(msg.id);
+            pending.delete(reqId);
             if (msg.error) {
               waiter.reject(new Error(msg.error.message ?? "ACP error"));
             } else {
@@ -523,7 +574,7 @@ export function runAcpStream(
           onAgentTextChunk: onChunk,
         });
       } catch {
-        /* ignore */
+        /* ignore notification handler errors */
       }
     });
 
@@ -574,7 +625,10 @@ export function runAcpStream(
           { cwd: opts.cwd, mcpServers: [] },
           pending,
           requestTimeoutMs,
-        )) as { sessionId?: string };
+        )) as {
+          sessionId?: string;
+          models?: { availableModels?: AcpAvailableModel[] };
+        };
         const sessionId = sessionResult?.sessionId;
         if (!sessionId) {
           finish(1);
@@ -582,15 +636,25 @@ export function runAcpStream(
         }
 
         if (opts.model) {
-          debugAcp("ACP step: session/set_config_option (model)");
-          await sendRequest(
-            child.stdin,
-            nextId,
-            "session/set_config_option",
-            { sessionId, option: "model", value: opts.model },
-            pending,
-            requestTimeoutMs,
+          const resolvedModelId = resolveAcpModelConfigValue(
+            opts.model,
+            sessionResult.models?.availableModels,
           );
+          if (resolvedModelId !== "auto" && resolvedModelId !== "default[]") {
+            debugAcp("ACP step: session/set_config_option (model)");
+            await sendRequest(
+              child.stdin,
+              nextId,
+              "session/set_config_option",
+              { sessionId, configId: "model", value: resolvedModelId },
+              pending,
+              requestTimeoutMs,
+            );
+          } else {
+            debugAcp(
+              "ACP step: session/set_config_option (model) — skipped, using session default",
+            );
+          }
         }
 
         debugAcp("ACP step: session/prompt");
@@ -602,7 +666,6 @@ export function runAcpStream(
       } catch {
         if (timeout) clearTimeout(timeout);
         if (!resolved) {
-          resolved = true;
           finish(1);
         }
       }

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -11,7 +11,7 @@ describe("loadBridgeConfig", () => {
     expect(config.host).toBe("127.0.0.1");
     expect(config.port).toBe(8765);
     expect(config.requiredKey).toBeUndefined();
-    expect(config.defaultModel).toBe("auto");
+    expect(config.defaultModel).toBe("default");
     expect(config.force).toBe(false);
     expect(config.approveMcps).toBe(false);
     expect(config.strictModel).toBe(true);

--- a/src/lib/env.test.ts
+++ b/src/lib/env.test.ts
@@ -13,7 +13,7 @@ describe("loadEnvConfig", () => {
     expect(loaded.agentBin).toBe("agent");
     expect(loaded.host).toBe("127.0.0.1");
     expect(loaded.port).toBe(8765);
-    expect(loaded.defaultModel).toBe("auto");
+    expect(loaded.defaultModel).toBe("default");
     expect(loaded.force).toBe(false);
     expect(loaded.approveMcps).toBe(false);
     expect(loaded.strictModel).toBe(true);

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -107,9 +107,9 @@ function envNumber(
 }
 
 function normalizeModelId(raw: string | undefined): string {
-  if (!raw) return "auto";
+  if (!raw) return "default";
   const parts = raw.split("/");
-  return parts[parts.length - 1] || "auto";
+  return parts[parts.length - 1] || "default";
 }
 
 function resolveAbsolutePath(

--- a/src/lib/handlers/anthropic-messages.ts
+++ b/src/lib/handlers/anthropic-messages.ts
@@ -58,7 +58,7 @@ export async function handleAnthropicMessages(
   const requested = normalizeModelId(body.model);
   const model = resolveModel(requested, lastRequestedModelRef, config);
   const displayModel =
-    requested === "auto" && config.defaultModel !== "auto"
+    requested === "default" && config.defaultModel !== "default"
       ? config.defaultModel
       : model;
 

--- a/src/lib/handlers/chat-completions.ts
+++ b/src/lib/handlers/chat-completions.ts
@@ -61,9 +61,9 @@ export async function handleChatCompletions(
   const requested = normalizeModelId(body.model);
   const model = resolveModel(requested, lastRequestedModelRef, config);
   const cursorModel = resolveToCursorModel(model) ?? model;
-  // When request is "auto", use defaultModel for response display (dashboard) if set; else echo "auto"
+  // When request is "default", use defaultModel for response display (dashboard) if set; else echo "default"
   const displayModel =
-    requested === "auto" && config.defaultModel !== "auto"
+    requested === "default" && config.defaultModel !== "default"
       ? config.defaultModel
       : model;
 

--- a/src/lib/resolve-model.ts
+++ b/src/lib/resolve-model.ts
@@ -9,12 +9,12 @@ export function resolveModel(
   lastRequestedModelRef: { current?: string },
   config: BridgeConfig,
 ): string {
-  const isAuto = requested === "auto";
-  const explicitModel = requested && !isAuto ? requested : undefined;
+  const isDefault = requested === "default";
+  const explicitModel = requested && !isDefault ? requested : undefined;
   if (explicitModel) lastRequestedModelRef.current = explicitModel;
 
-  // "auto" is a valid Cursor model identifier — pass it through directly
-  if (isAuto) return "auto";
+  // "default" matches ACP catalog name for session default model — pass through directly
+  if (isDefault) return "default";
 
   return (
     explicitModel ??

--- a/src/lib/server.test.ts
+++ b/src/lib/server.test.ts
@@ -53,7 +53,7 @@ function createTestConfig(overrides: Partial<BridgeConfig> = {}): BridgeConfig {
     acpEnv: {},
     host: "127.0.0.1",
     port: 0, // Let OS assign a free port
-    defaultModel: "auto",
+    defaultModel: "default",
     mode: "ask",
     force: false,
     approveMcps: false,
@@ -135,7 +135,7 @@ describe("startBridgeServer", () => {
     const data = JSON.parse(body);
     expect(data.ok).toBe(true);
     expect(data.version).toBe("1.0.0");
-    expect(data.defaultModel).toBe("auto");
+    expect(data.defaultModel).toBe("default");
   });
 
   it("responds 200 on GET /v1/models", async () => {
@@ -226,7 +226,7 @@ describe("startBridgeServer", () => {
     expect(data.choices[0].message.content).toBe("Hello from agent");
   });
 
-  it("returns display model when request is auto and defaultModel is set", async () => {
+  it("returns display model when request is default and defaultModel is set", async () => {
     servers = startBridgeServer({
       version: "0.1.0",
       config: createTestConfig({ defaultModel: "composer-1.5" }),
@@ -241,7 +241,7 @@ describe("startBridgeServer", () => {
       {
         method: "POST",
         body: JSON.stringify({
-          model: "auto",
+          model: "default",
           messages: [{ role: "user", content: "Hi" }],
         }),
       },
@@ -251,10 +251,10 @@ describe("startBridgeServer", () => {
     expect(data.model).toBe("composer-1.5");
   });
 
-  it("echoes auto when request is auto and defaultModel is unset", async () => {
+  it("echoes default when request is default and defaultModel is unset", async () => {
     servers = startBridgeServer({
       version: "0.1.0",
-      config: createTestConfig({ defaultModel: "auto" }),
+      config: createTestConfig({ defaultModel: "default" }),
     });
     await new Promise<void>((resolve) =>
       servers[0].on("listening", () => resolve()),
@@ -266,14 +266,14 @@ describe("startBridgeServer", () => {
       {
         method: "POST",
         body: JSON.stringify({
-          model: "auto",
+          model: "default",
           messages: [{ role: "user", content: "Hi" }],
         }),
       },
     );
     expect(status).toBe(200);
     const data = JSON.parse(body);
-    expect(data.model).toBe("auto");
+    expect(data.model).toBe("default");
   });
 
   it("should spawn multiple servers when multiPort is true", async () => {

--- a/src/lib/win-cmdline-limit.test.ts
+++ b/src/lib/win-cmdline-limit.test.ts
@@ -43,7 +43,7 @@ describe("fitPromptToWinCmdline", () => {
     "--workspace",
     "/tmp/ws",
     "--model",
-    "auto",
+    "default",
     "--output-format",
     "text",
   ];

--- a/src/lib/workspace.test.ts
+++ b/src/lib/workspace.test.ts
@@ -13,7 +13,7 @@ function baseConfig(overrides: Partial<BridgeConfig> = {}): BridgeConfig {
     acpEnv: {},
     host: "127.0.0.1",
     port: 8765,
-    defaultModel: "auto",
+    defaultModel: "default",
     mode: "ask",
     force: false,
     approveMcps: false,


### PR DESCRIPTION
## Summary

Fixes ACP `session/set_config_option` for current Cursor agent JSON-RPC expectations, and aligns the OpenAI-style "session default" sentinel with Cursor's model catalog.

## Changes

1. **Correct RPC shape**: use `value` (full `modelId`), not `configValue`, in `session/set_config_option` params (`runAcpSync` / `runAcpStream`).
2. **Skip redundant config**: when the resolved id is `default` or `default[]`, skip `set_config_option` (session already on Cursor default).
3. **Sentinel rename**: internal "use default" sentinel is `default` instead of `auto` (`normalizeModelId`, `resolveModel`, handlers, SDK client default), matching ACP `availableModels` (`name: "default"` → `default[]`).
4. **Tests**: extend fake ACP server scenarios; assert outbound `set_config_option` payloads; cover skip path, empty catalog, duplicate names, and error parity.

## Verification

- `npm test` — 165 tests
- `npm run build` — `tsc` clean

## Note

`dist/` is gitignored; consumers should run `npm run build` after install.

---

Cherry-picked from Azukay fork work; rebased onto current `main` (`upstream/main` at cherry-pick time).