### PR TITLE
chore(release): 0.7.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,7 @@ CLI flags:
 | Flag           | Description                                                                                |
 | -------------- | ------------------------------------------------------------------------------------------ |
 | `--tailscale`  | Bind to `0.0.0.0` for access from tailnet/LAN (unless `CURSOR_BRIDGE_HOST` is already set) |
+| `--verbose`    | Enable verbose logs (request/response previews + model resolution chain)                    |
 | `-h`, `--help` | Show CLI usage                                                                             |
 
 Optional per-request override: send header `X-Cursor-Workspace: <path>` to use a subdirectory of `CURSOR_BRIDGE_WORKSPACE` for that request (requires `CURSOR_BRIDGE_CHAT_ONLY_WORKSPACE=false` and an existing path on the proxy host).

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cursor-api-proxy",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cursor-api-proxy",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "dependencies": {
         "chrome-launcher": "^1.2.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cursor-api-proxy",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "OpenAI-compatible proxy for Cursor CLI — use Cursor models from any LLM client on localhost",
   "private": false,
   "type": "module",

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -13,7 +13,12 @@ import { describe, it, expect } from "vitest";
 import { parseArgs } from "./cli.js";
 
 describe("parseArgs", () => {
-  const base = { resetHwid: false, deepClean: false, dryRun: false };
+  const base = {
+    resetHwid: false,
+    deepClean: false,
+    dryRun: false,
+    verbose: false,
+  };
 
   it("parses empty argv", () => {
     expect(parseArgs([])).toEqual({
@@ -72,6 +77,20 @@ describe("parseArgs", () => {
       ...base,
       tailscale: true,
       help: true,
+      login: false,
+      logout: false,
+      accountsList: false,
+      accountName: "",
+      proxies: [],
+    });
+  });
+
+  it("parses --verbose", () => {
+    expect(parseArgs(["--verbose"])).toEqual({
+      ...base,
+      verbose: true,
+      tailscale: false,
+      help: false,
       login: false,
       logout: false,
       accountsList: false,

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -57,7 +57,10 @@ async function main(): Promise<void> {
     return;
   }
 
-  const config = loadBridgeConfig({ tailscale: args.tailscale });
+  const mergedEnv = args.verbose
+    ? { ...process.env, CURSOR_BRIDGE_VERBOSE: "true" }
+    : process.env;
+  const config = loadBridgeConfig({ tailscale: args.tailscale, env: mergedEnv });
   const servers = startBridgeServer({ version: pkg.version, config });
   setupGracefulShutdown(servers);
 }

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -1,5 +1,6 @@
 export type ParsedArgs = {
   tailscale: boolean;
+  verbose: boolean;
   help: boolean;
   login: boolean;
   accountsList: boolean;
@@ -13,6 +14,7 @@ export type ParsedArgs = {
 
 export function parseArgs(argv: string[]): ParsedArgs {
   let tailscale = false;
+  let verbose = false;
   let help = false;
   let login = false;
   let accountsList = false;
@@ -67,6 +69,11 @@ export function parseArgs(argv: string[]): ParsedArgs {
       continue;
     }
 
+    if (arg === "--verbose") {
+      verbose = true;
+      continue;
+    }
+
     if (arg === "--help" || arg === "-h") {
       help = true;
       continue;
@@ -86,6 +93,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
 
   return {
     tailscale,
+    verbose,
     help,
     login,
     accountsList,
@@ -122,5 +130,6 @@ export function printHelp(version: string): void {
   console.log("");
   console.log("Options:");
   console.log("  --tailscale     Bind to 0.0.0.0 for tailnet/LAN access");
+  console.log("  --verbose       Enable verbose request/model logs");
   console.log("  -h, --help      Show this help message");
 }

--- a/src/lib/acp-client.test.ts
+++ b/src/lib/acp-client.test.ts
@@ -34,10 +34,10 @@ describe("resolveAcpModelConfigValue", () => {
     ).toBe("gpt-4[fast=false]");
   });
 
-  it("returns pass-through when name not in catalog", () => {
+  it("falls back to default[] when name not in catalog", () => {
     expect(
       resolveAcpModelConfigValue("unknown", [{ modelId: "x[]", name: "gpt-4" }]),
-    ).toBe("unknown");
+    ).toBe("default[]");
   });
 
   it("uses first match when duplicate names", () => {

--- a/src/lib/acp-client.ts
+++ b/src/lib/acp-client.ts
@@ -200,7 +200,7 @@ export type AcpAvailableModel = { modelId: string; name: string };
 /**
  * Map OpenAI-style display name to Cursor ACP `modelId` (e.g. `composer-2` → `composer-2[fast=true]`).
  * If `availableModels` is missing or empty, returns `displayName` unchanged.
- * If the list is non-empty but no row matches `name`, logs via debug and returns `displayName` (pass-through).
+ * If the list is non-empty but no row matches `name`, logs via debug and falls back to session default.
  * Duplicate `name` entries: first match wins.
  */
 export function resolveAcpModelConfigValue(
@@ -211,10 +211,10 @@ export function resolveAcpModelConfigValue(
   const hit = availableModels.find((m) => m.name === displayName);
   if (!hit) {
     debugAcp(
-      "ACP model: no catalog match for display name %j; using value as-is",
+      "ACP model: no catalog match for display name %j; falling back to default[]",
       displayName,
     );
-    return displayName;
+    return "default[]";
   }
   return hit.modelId;
 }

--- a/src/lib/handlers/anthropic-messages.ts
+++ b/src/lib/handlers/anthropic-messages.ts
@@ -7,18 +7,21 @@ import { buildAgentFixedArgs } from "../agent-cmd-args.js";
 import { runAgentStream, runAgentSync } from "../agent-runner.js";
 import { createStreamParser } from "../cli-stream-parser.js";
 import type { BridgeConfig } from "../config.js";
+import type { ModelCacheRef } from "./models.js";
+import { getCachedCursorModels } from "./models.js";
 import { json, writeSseHeaders } from "../http.js";
-import { resolveToCursorModel } from "../model-map.js";
+import { resolveModelForExecution } from "../model-map.js";
 import { normalizeModelId, toolsToSystemText } from "../openai.js";
 import {
   logAgentError,
   logAccountAssigned,
   logAccountStats,
+  logModelResolution,
   logTrafficRequest,
   logTrafficResponse,
   type TrafficMessage,
 } from "../request-log.js";
-import { resolveModel } from "../resolve-model.js";
+import { rememberResolvedModel, resolveModel } from "../resolve-model.js";
 import { resolveWorkspace } from "../workspace.js";
 import { sanitizeMessages, sanitizeSystem } from "../sanitize.js";
 import {
@@ -42,6 +45,7 @@ function isRateLimited(stderr: string): boolean {
 export type AnthropicMessagesCtx = {
   config: BridgeConfig;
   lastRequestedModelRef: { current?: string };
+  modelCacheRef: ModelCacheRef;
 };
 
 export async function handleAnthropicMessages(
@@ -53,12 +57,21 @@ export async function handleAnthropicMessages(
   pathname: string,
   remoteAddress: string,
 ): Promise<void> {
-  const { config, lastRequestedModelRef } = ctx;
+  const { config, lastRequestedModelRef, modelCacheRef } = ctx;
   const body = JSON.parse(rawBody || "{}") as AnthropicMessagesRequest;
   const requested = normalizeModelId(body.model);
   const model = resolveModel(requested, lastRequestedModelRef, config);
+  const models = await getCachedCursorModels(config, modelCacheRef);
+  const decision = resolveModelForExecution({
+    requested: model,
+    defaultModel: config.defaultModel,
+    availableCursorIds: models.map((m) => m.id),
+  });
+  const cursorModel = decision.final;
+  rememberResolvedModel(cursorModel, lastRequestedModelRef);
+  logModelResolution(config.verbose, decision);
   const displayModel =
-    requested === "default" && config.defaultModel !== "default"
+    decision.requestedWasDefault && config.defaultModel !== "default"
       ? config.defaultModel
       : model;
 
@@ -85,8 +98,6 @@ export async function handleAnthropicMessages(
     });
     return;
   }
-
-  const cursorModel = resolveToCursorModel(model) ?? model;
 
   const trafficMessages: TrafficMessage[] = [];
   if (cleanSystem) {

--- a/src/lib/handlers/chat-completions.ts
+++ b/src/lib/handlers/chat-completions.ts
@@ -2,11 +2,13 @@ import { randomUUID } from "node:crypto";
 import * as http from "node:http";
 
 import type { BridgeConfig } from "../config.js";
+import type { ModelCacheRef } from "./models.js";
+import { getCachedCursorModels } from "./models.js";
 import { buildAgentFixedArgs } from "../agent-cmd-args.js";
 import { runAgentStream, runAgentSync } from "../agent-runner.js";
 import { createStreamParser } from "../cli-stream-parser.js";
 import { json, writeSseHeaders } from "../http.js";
-import { resolveToCursorModel } from "../model-map.js";
+import { resolveModelForExecution } from "../model-map.js";
 import {
   buildPromptFromMessages,
   normalizeModelId,
@@ -17,11 +19,12 @@ import {
   logAgentError,
   logAccountAssigned,
   logAccountStats,
+  logModelResolution,
   logTrafficRequest,
   logTrafficResponse,
   type TrafficMessage,
 } from "../request-log.js";
-import { resolveModel } from "../resolve-model.js";
+import { rememberResolvedModel, resolveModel } from "../resolve-model.js";
 import { resolveWorkspace } from "../workspace.js";
 import { sanitizeMessages } from "../sanitize.js";
 import {
@@ -45,6 +48,7 @@ function isRateLimited(stderr: string): boolean {
 export type ChatCompletionsCtx = {
   config: BridgeConfig;
   lastRequestedModelRef: { current?: string };
+  modelCacheRef: ModelCacheRef;
 };
 
 export async function handleChatCompletions(
@@ -56,14 +60,22 @@ export async function handleChatCompletions(
   pathname: string,
   remoteAddress: string,
 ): Promise<void> {
-  const { config, lastRequestedModelRef } = ctx;
+  const { config, lastRequestedModelRef, modelCacheRef } = ctx;
   const body = JSON.parse(rawBody || "{}") as OpenAiChatCompletionRequest;
   const requested = normalizeModelId(body.model);
   const model = resolveModel(requested, lastRequestedModelRef, config);
-  const cursorModel = resolveToCursorModel(model) ?? model;
+  const models = await getCachedCursorModels(config, modelCacheRef);
+  const decision = resolveModelForExecution({
+    requested: model,
+    defaultModel: config.defaultModel,
+    availableCursorIds: models.map((m) => m.id),
+  });
+  const cursorModel = decision.final;
+  rememberResolvedModel(cursorModel, lastRequestedModelRef);
+  logModelResolution(config.verbose, decision);
   // When request is "default", use defaultModel for response display (dashboard) if set; else echo "default"
   const displayModel =
-    requested === "default" && config.defaultModel !== "default"
+    decision.requestedWasDefault && config.defaultModel !== "default"
       ? config.defaultModel
       : model;
 

--- a/src/lib/handlers/models.ts
+++ b/src/lib/handlers/models.ts
@@ -9,17 +9,20 @@ import { getAnthropicModelAliases } from "../model-map.js";
 const MODEL_CACHE_TTL_MS = 5 * 60_000;
 
 export type ModelCache = { at: number; models: CursorCliModel[] };
+export type ModelCacheRef = {
+  current?: ModelCache;
+  inflight?: Promise<CursorCliModel[]>;
+};
 
 export type HandleModelsOpts = {
   config: BridgeConfig;
-  modelCacheRef: { current?: ModelCache; inflight?: Promise<CursorCliModel[]> };
+  modelCacheRef: ModelCacheRef;
 };
 
-export async function handleModels(
-  res: http.ServerResponse,
-  opts: HandleModelsOpts,
-): Promise<void> {
-  const { config, modelCacheRef } = opts;
+export async function getCachedCursorModels(
+  config: BridgeConfig,
+  modelCacheRef: ModelCacheRef,
+): Promise<CursorCliModel[]> {
   const now = Date.now();
   if (
     !modelCacheRef.current ||
@@ -44,8 +47,15 @@ export async function handleModels(
     }
     await modelCacheRef.inflight;
   }
+  return modelCacheRef.current?.models ?? [];
+}
 
-  const models = modelCacheRef.current?.models ?? [];
+export async function handleModels(
+  res: http.ServerResponse,
+  opts: HandleModelsOpts,
+): Promise<void> {
+  const { config, modelCacheRef } = opts;
+  const models = await getCachedCursorModels(config, modelCacheRef);
   const cursorModels = models.map((m) => ({
     id: m.id,
     object: "model" as const,

--- a/src/lib/model-map.test.ts
+++ b/src/lib/model-map.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from "vitest";
+
+import { resolveModelForExecution, resolveToCursorModel } from "./model-map.js";
+
+describe("resolveToCursorModel", () => {
+  it("maps dated sonnet id to cursor sonnet-4.5", () => {
+    expect(resolveToCursorModel("claude-sonnet-4-5-20250929")).toBe("sonnet-4.5");
+  });
+
+  it("maps dated opus id with v-suffix", () => {
+    expect(resolveToCursorModel("claude-opus-4-6-20260101-v1")).toBe("opus-4.6");
+  });
+
+  it("maps dated haiku id to sonnet fallback", () => {
+    expect(resolveToCursorModel("claude-haiku-4-5-20251001")).toBe("sonnet-4.5");
+  });
+});
+
+describe("resolveModelForExecution", () => {
+  it("uses mapped model when available", () => {
+    const decision = resolveModelForExecution({
+      requested: "claude-sonnet-4-5-20250929",
+      defaultModel: "auto",
+      availableCursorIds: ["auto", "sonnet-4.5"],
+    });
+    expect(decision.final).toBe("sonnet-4.5");
+    expect(decision.fallbackUsed).toBe(false);
+    expect(decision.validated).toBe(true);
+  });
+
+  it("falls back to default model when mapped model is unavailable", () => {
+    const decision = resolveModelForExecution({
+      requested: "claude-sonnet-4-5-20250929",
+      defaultModel: "auto",
+      availableCursorIds: ["auto", "gpt-5.2"],
+    });
+    expect(decision.final).toBe("auto");
+    expect(decision.fallbackUsed).toBe(true);
+    expect(decision.fallbackReason).toBe("mapped_model_unavailable");
+  });
+
+  it("prefers explicit default request", () => {
+    const decision = resolveModelForExecution({
+      requested: "default",
+      defaultModel: "auto",
+      availableCursorIds: ["auto"],
+    });
+    expect(decision.final).toBe("default");
+    expect(decision.requestedWasDefault).toBe(true);
+  });
+});

--- a/src/lib/model-map.ts
+++ b/src/lib/model-map.ts
@@ -3,6 +3,16 @@
  * so clients like Claude Code can send "claude-opus-4-6" and the proxy uses "opus-4.6".
  */
 
+export type ModelResolutionDecision = {
+  requested?: string;
+  mapped?: string;
+  final: string;
+  requestedWasDefault: boolean;
+  validated: boolean;
+  fallbackUsed: boolean;
+  fallbackReason?: string;
+};
+
 /** Anthropic-style model name (any case) -> Cursor CLI model id */
 const ANTHROPIC_TO_CURSOR: Record<string, string> = {
   // Claude 4.6
@@ -42,14 +52,129 @@ const CURSOR_TO_ANTHROPIC_ALIAS: Array<{ cursorId: string; anthropicId: string; 
   { cursorId: "sonnet-4.5-thinking", anthropicId: "claude-sonnet-4-5-thinking", name: "Claude 4.5 Sonnet (Thinking)" },
 ];
 
+function normalizeForLookup(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function mapClaudeDatedVariant(key: string): string | undefined {
+  const trimmed = key.trim().toLowerCase();
+  const simplified = trimmed.replace(/-v\d+$/i, "");
+  const match = simplified.match(
+    /^claude-(opus|sonnet|haiku)-4(?:[.-](5|6))?(?:-thinking)?(?:-\d{8})?$/,
+  );
+  if (!match) return undefined;
+
+  const family = match[1];
+  const version = match[2];
+  const isThinking = simplified.includes("-thinking");
+
+  const normalizedFamily = family === "haiku" ? "sonnet" : family;
+  const normalizedVersion = version ?? "6";
+  const suffix = isThinking ? "-thinking" : "";
+  return `${normalizedFamily}-4.${normalizedVersion}${suffix}`;
+}
+
 /**
  * Resolve a requested model (e.g. from the client) to the Cursor CLI model ID.
  * If the request uses an Anthropic-style name, returns the mapped Cursor ID; otherwise returns the value as-is.
  */
 export function resolveToCursorModel(requested: string | undefined): string | undefined {
   if (!requested || !requested.trim()) return undefined;
-  const key = requested.trim().toLowerCase();
-  return ANTHROPIC_TO_CURSOR[key] ?? requested.trim();
+  const key = normalizeForLookup(requested);
+  return ANTHROPIC_TO_CURSOR[key] ?? mapClaudeDatedVariant(key) ?? requested.trim();
+}
+
+function matchAvailableModel(
+  candidate: string | undefined,
+  availableCursorIds: string[],
+): string | undefined {
+  if (!candidate) return undefined;
+  const byLower = new Map(availableCursorIds.map((id) => [id.toLowerCase(), id]));
+  return byLower.get(candidate.toLowerCase());
+}
+
+export function resolveModelForExecution(args: {
+  requested: string | undefined;
+  defaultModel: string;
+  availableCursorIds: string[];
+}): ModelResolutionDecision {
+  const requested = args.requested?.trim();
+  const requestedWasDefault = requested === "default";
+  const mapped = requestedWasDefault
+    ? "default"
+    : resolveToCursorModel(requested) ?? args.defaultModel;
+
+  if (mapped === "default") {
+    return {
+      requested,
+      mapped,
+      final: "default",
+      requestedWasDefault,
+      validated: true,
+      fallbackUsed: false,
+    };
+  }
+
+  const matchedMapped = matchAvailableModel(mapped, args.availableCursorIds);
+  if (matchedMapped) {
+    return {
+      requested,
+      mapped,
+      final: matchedMapped,
+      requestedWasDefault,
+      validated: true,
+      fallbackUsed: false,
+    };
+  }
+
+  const matchedDefault = matchAvailableModel(args.defaultModel, args.availableCursorIds);
+  if (matchedDefault) {
+    return {
+      requested,
+      mapped,
+      final: matchedDefault,
+      requestedWasDefault,
+      validated: true,
+      fallbackUsed: true,
+      fallbackReason: "mapped_model_unavailable",
+    };
+  }
+
+  const matchedAuto = matchAvailableModel("auto", args.availableCursorIds);
+  if (matchedAuto) {
+    return {
+      requested,
+      mapped,
+      final: matchedAuto,
+      requestedWasDefault,
+      validated: true,
+      fallbackUsed: true,
+      fallbackReason: "mapped_model_unavailable",
+    };
+  }
+
+  const firstAvailable = args.availableCursorIds[0];
+  if (firstAvailable) {
+    return {
+      requested,
+      mapped,
+      final: firstAvailable,
+      requestedWasDefault,
+      validated: true,
+      fallbackUsed: true,
+      fallbackReason: "mapped_model_unavailable",
+    };
+  }
+
+  return {
+    requested,
+    mapped,
+    final: mapped,
+    requestedWasDefault,
+    validated: false,
+    fallbackUsed: false,
+    fallbackReason: "catalog_unavailable",
+  };
 }
 
 /**

--- a/src/lib/request-listener.ts
+++ b/src/lib/request-listener.ts
@@ -3,7 +3,7 @@ import * as fs from "node:fs";
 import * as http from "node:http";
 
 import type { BridgeConfig } from "./config.js";
-import type { ModelCache } from "./handlers/models.js";
+import type { ModelCacheRef } from "./handlers/models.js";
 import { handleHealth } from "./handlers/health.js";
 import { handleModels } from "./handlers/models.js";
 import { handleChatCompletions } from "./handlers/chat-completions.js";
@@ -18,7 +18,7 @@ export type BridgeServerOptions = {
 
 export function createRequestListener(opts: BridgeServerOptions) {
   const { config } = opts;
-  const modelCacheRef: { current?: ModelCache } = { current: undefined };
+  const modelCacheRef: ModelCacheRef = { current: undefined };
   const lastRequestedModelRef: { current?: string } = {};
 
   return async (req: http.IncomingMessage, res: http.ServerResponse) => {
@@ -73,7 +73,7 @@ export function createRequestListener(opts: BridgeServerOptions) {
         await handleChatCompletions(
           req,
           res,
-          { config, lastRequestedModelRef },
+          { config, lastRequestedModelRef, modelCacheRef },
           raw,
           method,
           pathname,
@@ -87,7 +87,7 @@ export function createRequestListener(opts: BridgeServerOptions) {
         await handleAnthropicMessages(
           req,
           res,
-          { config, lastRequestedModelRef },
+          { config, lastRequestedModelRef, modelCacheRef },
           raw,
           method,
           pathname,

--- a/src/lib/request-log.ts
+++ b/src/lib/request-log.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 
 import type { AccountStat } from "./account-pool.js";
+import type { ModelResolutionDecision } from "./model-map.js";
 
 export function logIncoming(
   method: string,
@@ -153,6 +154,24 @@ export function logTrafficResponse(
   );
   console.log(`  🤖 ${C.green}${preview}${C.reset}`);
   console.log(hr("─", 60));
+}
+
+export function logModelResolution(
+  verbose: boolean,
+  decision: ModelResolutionDecision,
+): void {
+  if (!verbose) return;
+  const requested = decision.requested ?? "(none)";
+  const mapped = decision.mapped ?? "(none)";
+  const fallback = decision.fallbackUsed
+    ? `${C.yellow}yes${C.reset}${decision.fallbackReason ? ` (${decision.fallbackReason})` : ""}`
+    : `${C.dim}no${C.reset}`;
+  const validated = decision.validated
+    ? `${C.green}yes${C.reset}`
+    : `${C.red}no${C.reset}`;
+  console.log(
+    `${ts()} ${C.bMagenta}MODEL${C.reset} requested=${C.white}${requested}${C.reset} mapped=${C.white}${mapped}${C.reset} final=${C.bold}${decision.final}${C.reset} validated=${validated} fallback=${fallback}`,
+  );
 }
 
 export function appendSessionLine(

--- a/src/lib/resolve-model.test.ts
+++ b/src/lib/resolve-model.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { rememberResolvedModel, resolveModel } from "./resolve-model.js";
+import type { BridgeConfig } from "./config.js";
+
+function config(overrides: Partial<BridgeConfig> = {}): BridgeConfig {
+  return {
+    agentBin: "agent",
+    acpCommand: "agent",
+    acpArgs: ["acp"],
+    acpEnv: {},
+    host: "127.0.0.1",
+    port: 8765,
+    defaultModel: "auto",
+    mode: "ask",
+    force: false,
+    approveMcps: false,
+    strictModel: true,
+    workspace: process.cwd(),
+    timeoutMs: 30_000,
+    sessionsLogPath: "/tmp/test.log",
+    chatOnlyWorkspace: true,
+    verbose: false,
+    maxMode: false,
+    promptViaStdin: false,
+    useAcp: false,
+    acpSkipAuthenticate: false,
+    acpRawDebug: false,
+    configDirs: [],
+    multiPort: false,
+    winCmdlineMax: 30_000,
+    ...overrides,
+  };
+}
+
+describe("resolveModel memory behavior", () => {
+  it("does not persist explicit model before validation", () => {
+    const ref: { current?: string } = {};
+    const resolved = resolveModel("claude-sonnet-4-5-20250929", ref, config());
+    expect(resolved).toBe("claude-sonnet-4-5-20250929");
+    expect(ref.current).toBeUndefined();
+  });
+
+  it("stores only final validated model", () => {
+    const ref: { current?: string } = {};
+    rememberResolvedModel("sonnet-4.5", ref);
+    expect(ref.current).toBe("sonnet-4.5");
+  });
+
+  it("does not store default sentinel", () => {
+    const ref: { current?: string } = {};
+    rememberResolvedModel("default", ref);
+    expect(ref.current).toBeUndefined();
+  });
+});

--- a/src/lib/resolve-model.ts
+++ b/src/lib/resolve-model.ts
@@ -11,7 +11,6 @@ export function resolveModel(
 ): string {
   const isDefault = requested === "default";
   const explicitModel = requested && !isDefault ? requested : undefined;
-  if (explicitModel) lastRequestedModelRef.current = explicitModel;
 
   // "default" matches ACP catalog name for session default model — pass through directly
   if (isDefault) return "default";
@@ -22,4 +21,15 @@ export function resolveModel(
     lastRequestedModelRef.current ??
     config.defaultModel
   );
+}
+
+/**
+ * Persist only the final model used for execution.
+ */
+export function rememberResolvedModel(
+  model: string,
+  lastRequestedModelRef: { current?: string },
+): void {
+  if (!model || model === "default") return;
+  lastRequestedModelRef.current = model;
 }

--- a/src/lib/server.test.ts
+++ b/src/lib/server.test.ts
@@ -37,6 +37,7 @@ vi.mock("./request-log.js", () => ({
   logIncoming: vi.fn(),
   logTrafficRequest: vi.fn(),
   logTrafficResponse: vi.fn(),
+  logModelResolution: vi.fn(),
   logAgentError: vi.fn().mockReturnValue("agent error"),
   appendSessionLine: vi.fn(),
   logAccountAssigned: vi.fn(),


### PR DESCRIPTION
## Summary
- harden model resolution pipeline with dated Claude alias mapping and catalog-based validation before agent execution
- add deterministic fallback behavior so unknown/unsupported models do not trigger Cursor CLI model errors
- add verbose model decision logging, CLI `--verbose` flag, docs updates, and regression tests for mapping/fallback/memory behavior

## Test plan
- [x] npm test
- [x] curl /v1/messages with dated Claude model id and verify successful response
- [x] curl /v1/messages with unknown model id and verify fallback path succeeds

Made with [Cursor](https://cursor.com)