### PR TITLE
chore(release): 1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ Environment handling is centralized in one module. Aliases, defaults, path resol
 | `CURSOR_BRIDGE_API_KEY` | — | If set, require `Authorization: Bearer <key>` on requests |
 | `CURSOR_API_KEY` / `CURSOR_AUTH_TOKEN` | — | Cursor access token passed to spawned CLI/ACP children (automation, headless). Same value can be used for both names. |
 | `CURSOR_BRIDGE_WORKSPACE` | process cwd | Base workspace directory for Cursor CLI. With `CURSOR_BRIDGE_CHAT_ONLY_WORKSPACE=false`, header `X-Cursor-Workspace` must point to an **existing directory under this path** (after resolving real paths). |
-| `CURSOR_BRIDGE_MODE` | — | Ignored; proxy always runs in **ask** (chat-only) mode so the CLI never creates or edits files. |
+| `CURSOR_BRIDGE_MODE` | — | Server default for Cursor CLI `--mode`: **`agent`**, **`ask`**, or **`plan`**. If unset, default is **`ask`**. **Env wins over** CLI `--mode` when both are set. Per request, JSON body **`mode`** or header **`X-Cursor-Mode`** overrides (precedence: body → header → this env → `--mode` → `ask`). Invalid value → startup error. With **`agent`** (or **`plan`**) and real workspace, the CLI may **read/write files** under `CURSOR_BRIDGE_WORKSPACE` / cwd—see `CURSOR_BRIDGE_CHAT_ONLY_WORKSPACE`. |
 | `CURSOR_BRIDGE_DEFAULT_MODEL` | `auto` | Default model when request omits one |
 | `CURSOR_BRIDGE_STRICT_MODEL` | `true` | Use last requested model when none specified |
 | `CURSOR_BRIDGE_FORCE` | `false` | Pass `--force` to Cursor CLI |
@@ -183,7 +183,7 @@ Environment handling is centralized in one module. Aliases, defaults, path resol
 | `CURSOR_BRIDGE_TLS_CERT` | — | Path to TLS certificate file (e.g. Tailscale cert). Use with `CURSOR_BRIDGE_TLS_KEY` for HTTPS. |
 | `CURSOR_BRIDGE_TLS_KEY` | — | Path to TLS private key file. Use with `CURSOR_BRIDGE_TLS_CERT` for HTTPS. |
 | `CURSOR_BRIDGE_SESSIONS_LOG` | `~/.cursor-api-proxy/sessions.log` | Path to log file; each request is appended as a line (timestamp, method, path, IP, status). |
-| `CURSOR_BRIDGE_CHAT_ONLY_WORKSPACE` | `true` | When `true` (default), the CLI runs in an empty temp dir so it **cannot read or write your project**; pure chat only. The proxy also overrides `HOME`, `USERPROFILE`, and `CURSOR_CONFIG_DIR` so the agent cannot load rules from `~/.cursor` or project rules from elsewhere. Set to `false` to pass the real workspace (e.g. for `X-Cursor-Workspace`). |
+| `CURSOR_BRIDGE_CHAT_ONLY_WORKSPACE` | `true` | When `true` (default), the CLI runs in an empty temp dir so it **cannot read or write your project**; pure chat only. The proxy also overrides `HOME`, `USERPROFILE`, and `CURSOR_CONFIG_DIR` so the agent cannot load rules from `~/.cursor` or project rules from elsewhere. Set to `false` to pass the real workspace (e.g. for `X-Cursor-Workspace`). **Mode interaction:** for a request whose effective mode is not **`ask`**, if this variable was **not set in the environment** (left at default), the proxy uses the **real workspace** for that request so `agent` / `plan` can touch files. If you **did** set this variable in the environment (to `true` or `false`), that choice is **always** honored for every request. |
 | `CURSOR_BRIDGE_VERBOSE` | `false` | When `true`, print full request messages and response content to stdout for every completion (both stream and sync). |
 | `CURSOR_BRIDGE_MAX_MODE` | `false` | When `true`, enable Cursor **Max Mode** for all requests (larger context window, higher tool-call limits). The proxy writes `maxMode: true` to `cli-config.json` before each run. Works when using `CURSOR_AGENT_NODE`/`CURSOR_AGENT_SCRIPT`, the versioned layout (`versions/YYYY.MM.DD-commit/`), or node.exe + index.js next to agent.cmd. |
 | `CURSOR_BRIDGE_WIN_CMDLINE_MAX` | `30000` | **(Windows)** Upper bound (UTF-16 units, pessimistic) for the full `CreateProcess` command line. If the prompt would exceed it, the proxy keeps the **tail** of the prompt and prepends a short omission notice, logs a warning, and sets `X-Cursor-Proxy-Prompt-Truncated: true` on the response. Clamped to `4096`–`32700`. |
@@ -231,9 +231,13 @@ CLI flags:
 | -------------- | ------------------------------------------------------------------------------------------ |
 | `--tailscale`  | Bind to `0.0.0.0` for access from tailnet/LAN (unless `CURSOR_BRIDGE_HOST` is already set) |
 | `--verbose`    | Enable verbose logs (request/response previews + model resolution chain)                    |
+| `--mode`       | Default Cursor CLI mode: `agent`, `ask`, or `plan` (default `ask` if omitted). Overridden by `CURSOR_BRIDGE_MODE` when set. |
 | `-h`, `--help` | Show CLI usage                                                                             |
 
-Optional per-request override: send header `X-Cursor-Workspace: <path>` to use a subdirectory of `CURSOR_BRIDGE_WORKSPACE` for that request (requires `CURSOR_BRIDGE_CHAT_ONLY_WORKSPACE=false` and an existing path on the proxy host).
+Optional per-request overrides:
+
+- Header **`X-Cursor-Workspace: <path>`** — use a subdirectory of `CURSOR_BRIDGE_WORKSPACE` (requires real workspace: set `CURSOR_BRIDGE_CHAT_ONLY_WORKSPACE=false` or use a non-`ask` mode without forcing chat-only; path must exist on the proxy host).
+- Header **`X-Cursor-Mode: <agent|ask|plan>`** or JSON body field **`mode`** — execution mode for that request (body wins over header).
 
 **CLI subcommands** (see `cursor-api-proxy --help`): `login <name>`, `accounts` (list), `logout`, `usage`, `reset-hwid` (see `--help` for options). Flags above still apply to the server entrypoint.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cursor-api-proxy",
-  "version": "0.7.2",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cursor-api-proxy",
-      "version": "0.7.2",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "chrome-launcher": "^1.2.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cursor-api-proxy",
-  "version": "0.7.2",
+  "version": "1.0.0",
   "description": "OpenAI-compatible proxy for Cursor CLI — use Cursor models from any LLM client on localhost",
   "private": false,
   "type": "module",

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -18,6 +18,7 @@ describe("parseArgs", () => {
     deepClean: false,
     dryRun: false,
     verbose: false,
+    mode: undefined as undefined,
   };
 
   it("parses empty argv", () => {
@@ -176,5 +177,41 @@ describe("parseArgs", () => {
     expect(() => parseArgs(["--unknown"])).toThrow(
       "Unknown argument: --unknown",
     );
+  });
+
+  it("parses --mode agent", () => {
+    expect(parseArgs(["--mode", "agent"])).toEqual({
+      ...base,
+      tailscale: false,
+      help: false,
+      login: false,
+      logout: false,
+      accountsList: false,
+      accountName: "",
+      proxies: [],
+      mode: "agent",
+    });
+  });
+
+  it("parses --mode=plan", () => {
+    expect(parseArgs(["--mode=plan"])).toEqual({
+      ...base,
+      tailscale: false,
+      help: false,
+      login: false,
+      logout: false,
+      accountsList: false,
+      accountName: "",
+      proxies: [],
+      mode: "plan",
+    });
+  });
+
+  it("throws on invalid --mode value", () => {
+    expect(() => parseArgs(["--mode", "bogus"])).toThrow(/invalid mode/);
+  });
+
+  it("throws when --mode has no value", () => {
+    expect(() => parseArgs(["--mode"])).toThrow(/requires a value/);
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -60,7 +60,11 @@ async function main(): Promise<void> {
   const mergedEnv = args.verbose
     ? { ...process.env, CURSOR_BRIDGE_VERBOSE: "true" }
     : process.env;
-  const config = loadBridgeConfig({ tailscale: args.tailscale, env: mergedEnv });
+  const config = loadBridgeConfig({
+    tailscale: args.tailscale,
+    env: mergedEnv,
+    mode: args.mode,
+  });
   const servers = startBridgeServer({ version: pkg.version, config });
   setupGracefulShutdown(servers);
 }

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -1,3 +1,6 @@
+import type { CursorExecutionMode } from "../lib/execution-mode.js";
+import { parseExecutionModeFromRequest } from "../lib/execution-mode.js";
+
 export type ParsedArgs = {
   tailscale: boolean;
   verbose: boolean;
@@ -10,6 +13,8 @@ export type ParsedArgs = {
   resetHwid: boolean;
   deepClean: boolean;
   dryRun: boolean;
+  /** Set via `--mode`; default applied in config when omitted. */
+  mode?: CursorExecutionMode;
 };
 
 export function parseArgs(argv: string[]): ParsedArgs {
@@ -24,6 +29,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
   let resetHwid = false;
   let deepClean = false;
   let dryRun = false;
+  let mode: CursorExecutionMode | undefined;
 
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
@@ -74,6 +80,22 @@ export function parseArgs(argv: string[]): ParsedArgs {
       continue;
     }
 
+    if (arg === "--mode") {
+      if (i + 1 >= argv.length || argv[i + 1]!.startsWith("-")) {
+        throw new Error("--mode requires a value (agent, ask, or plan)");
+      }
+      mode = parseExecutionModeFromRequest(argv[++i]!, "--mode");
+      continue;
+    }
+
+    if (arg.startsWith("--mode=")) {
+      mode = parseExecutionModeFromRequest(
+        arg.slice("--mode=".length),
+        "--mode",
+      );
+      continue;
+    }
+
     if (arg === "--help" || arg === "-h") {
       help = true;
       continue;
@@ -103,6 +125,7 @@ export function parseArgs(argv: string[]): ParsedArgs {
     resetHwid,
     deepClean,
     dryRun,
+    mode,
   };
 }
 
@@ -131,5 +154,8 @@ export function printHelp(version: string): void {
   console.log("Options:");
   console.log("  --tailscale     Bind to 0.0.0.0 for tailnet/LAN access");
   console.log("  --verbose       Enable verbose request/model logs");
+  console.log(
+    "  --mode <agent|ask|plan>  Default Cursor CLI mode (overridden by env or per-request)",
+  );
   console.log("  -h, --help      Show this help message");
 }

--- a/src/lib/agent-cmd-args.test.ts
+++ b/src/lib/agent-cmd-args.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { buildAgentFixedArgs } from "./agent-cmd-args.js";
+import type { BridgeConfig } from "./config.js";
+
+function cfg(overrides: Partial<BridgeConfig> = {}): BridgeConfig {
+  return {
+    agentBin: "agent",
+    acpCommand: "agent",
+    acpArgs: ["acp"],
+    acpEnv: {},
+    host: "127.0.0.1",
+    port: 8765,
+    defaultModel: "default",
+    mode: "ask",
+    force: false,
+    approveMcps: false,
+    strictModel: true,
+    workspace: "/w",
+    timeoutMs: 30_000,
+    sessionsLogPath: "/tmp/s.log",
+    chatOnlyWorkspace: true,
+    chatOnlyWorkspaceExplicit: false,
+    verbose: false,
+    maxMode: false,
+    promptViaStdin: false,
+    useAcp: false,
+    acpSkipAuthenticate: true,
+    acpRawDebug: false,
+    configDirs: [],
+    multiPort: false,
+    winCmdlineMax: 30_000,
+    ...overrides,
+  };
+}
+
+describe("buildAgentFixedArgs", () => {
+  it("passes --mode and --trust when effectiveChatOnly", () => {
+    const args = buildAgentFixedArgs(
+      cfg(),
+      "/ws",
+      "gpt-5",
+      false,
+      "agent",
+      true,
+    );
+    expect(args).toContain("--mode");
+    expect(args[args.indexOf("--mode") + 1]).toBe("agent");
+    expect(args).toContain("--trust");
+  });
+
+  it("omits --trust when not effectiveChatOnly", () => {
+    const args = buildAgentFixedArgs(
+      cfg({ chatOnlyWorkspace: true }),
+      "/ws",
+      "gpt-5",
+      false,
+      "ask",
+      false,
+    );
+    expect(args).not.toContain("--trust");
+  });
+});

--- a/src/lib/agent-cmd-args.ts
+++ b/src/lib/agent-cmd-args.ts
@@ -1,4 +1,5 @@
 import type { BridgeConfig } from "./config.js";
+import type { CursorExecutionMode } from "./execution-mode.js";
 
 /**
  * CLI flags and options for the Cursor agent, excluding the final prompt argument.
@@ -8,12 +9,14 @@ export function buildAgentFixedArgs(
   workspaceDir: string,
   model: string,
   stream: boolean,
+  mode: CursorExecutionMode,
+  effectiveChatOnly: boolean,
 ): string[] {
   const args = ["--print"];
   if (config.approveMcps) args.push("--approve-mcps");
   if (config.force) args.push("--force");
-  if (config.chatOnlyWorkspace) args.push("--trust");
-  args.push("--mode", "ask");
+  if (effectiveChatOnly) args.push("--trust");
+  args.push("--mode", mode);
   args.push("--workspace", workspaceDir);
   args.push("--model", model);
   if (stream) {
@@ -33,6 +36,18 @@ export function buildAgentCmdArgs(
   model: string,
   prompt: string,
   stream: boolean,
+  mode: CursorExecutionMode,
+  effectiveChatOnly: boolean,
 ): string[] {
-  return [...buildAgentFixedArgs(config, workspaceDir, model, stream), prompt];
+  return [
+    ...buildAgentFixedArgs(
+      config,
+      workspaceDir,
+      model,
+      stream,
+      mode,
+      effectiveChatOnly,
+    ),
+    prompt,
+  ];
 }

--- a/src/lib/agent-runner.ts
+++ b/src/lib/agent-runner.ts
@@ -2,6 +2,7 @@ import * as fs from "node:fs";
 
 import { runAcpStream, runAcpSync } from "./acp-client.js";
 import type { BridgeConfig } from "./config.js";
+import type { CursorExecutionMode } from "./execution-mode.js";
 import { run, runStreaming } from "./process.js";
 import { getChatOnlyEnvOverrides } from "./workspace.js";
 import { readKeychainToken, writeCachedToken } from "./token-cache.js";
@@ -24,6 +25,12 @@ function acpArgsWithModel(acpArgs: string[], model: string): string[] {
   return [...acpArgs.slice(0, i + 1), "--model", model, ...acpArgs.slice(i + 1)];
 }
 
+function acpArgsWithMode(acpArgs: string[], mode: CursorExecutionMode): string[] {
+  const i = acpArgs.indexOf("acp");
+  if (i === -1) return acpArgs;
+  return [...acpArgs.slice(0, i + 1), "--mode", mode, ...acpArgs.slice(i + 1)];
+}
+
 function acpArgsWithWorkspace(acpArgs: string[], workspaceDir: string): string[] {
   const i = acpArgs.indexOf("acp");
   if (i === -1) return acpArgs;
@@ -35,9 +42,18 @@ function extractModelFromCmdArgs(cmdArgs: string[]): string | undefined {
   return i >= 0 && i + 1 < cmdArgs.length ? cmdArgs[i + 1] : undefined;
 }
 
+function extractModeFromCmdArgs(cmdArgs: string[]): CursorExecutionMode {
+  const i = cmdArgs.indexOf("--mode");
+  const m =
+    i >= 0 && i + 1 < cmdArgs.length ? cmdArgs[i + 1] : undefined;
+  if (m === "agent" || m === "ask" || m === "plan") return m;
+  return "ask";
+}
+
 export function runAgentSync(
   config: BridgeConfig,
   workspaceDir: string,
+  effectiveChatOnly: boolean,
   cmdArgs: string[],
   tempDir?: string,
   stdinPrompt?: string,
@@ -46,10 +62,12 @@ export function runAgentSync(
 ): Promise<AgentRunResult> {
   if (config.useAcp && typeof stdinPrompt === "string") {
     const acpModel = extractModelFromCmdArgs(cmdArgs);
+    const acpMode = extractModeFromCmdArgs(cmdArgs);
     let args = acpArgsWithWorkspace(config.acpArgs, workspaceDir);
     args = acpModel ? acpArgsWithModel(args, acpModel) : args;
+    args = acpArgsWithMode(args, acpMode);
     const acpEnv = { ...config.acpEnv };
-    if (config.chatOnlyWorkspace) {
+    if (effectiveChatOnly) {
       Object.assign(acpEnv, getChatOnlyEnvOverrides(workspaceDir, configDir));
     }
     return runAcpSync(config.acpCommand, args, stdinPrompt, {
@@ -74,7 +92,7 @@ export function runAgentSync(
       return out;
     });
   }
-  const runEnvOverrides = config.chatOnlyWorkspace
+  const runEnvOverrides = effectiveChatOnly
     ? getChatOnlyEnvOverrides(workspaceDir, configDir)
     : undefined;
   return run(config.agentBin, cmdArgs, {
@@ -103,6 +121,7 @@ export type StreamLineHandler = (line: string) => void;
 export function runAgentStream(
   config: BridgeConfig,
   workspaceDir: string,
+  effectiveChatOnly: boolean,
   cmdArgs: string[],
   onLine: StreamLineHandler,
   tempDir?: string,
@@ -112,10 +131,12 @@ export function runAgentStream(
 ): Promise<{ code: number; stderr: string }> {
   if (config.useAcp && typeof stdinPrompt === "string") {
     const acpModel = extractModelFromCmdArgs(cmdArgs);
+    const acpMode = extractModeFromCmdArgs(cmdArgs);
     let args = acpArgsWithWorkspace(config.acpArgs, workspaceDir);
     args = acpModel ? acpArgsWithModel(args, acpModel) : args;
+    args = acpArgsWithMode(args, acpMode);
     const acpEnv = { ...config.acpEnv };
-    if (config.chatOnlyWorkspace) {
+    if (effectiveChatOnly) {
       Object.assign(acpEnv, getChatOnlyEnvOverrides(workspaceDir, configDir));
     }
     return runAcpStream(
@@ -146,7 +167,7 @@ export function runAgentStream(
       return result;
     });
   }
-  const streamEnvOverrides = config.chatOnlyWorkspace
+  const streamEnvOverrides = effectiveChatOnly
     ? getChatOnlyEnvOverrides(workspaceDir, configDir)
     : undefined;
   return runStreaming(config.agentBin, cmdArgs, {

--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -12,6 +12,8 @@ export type AnthropicMessageParam = {
 
 export type AnthropicMessagesRequest = {
   model?: string;
+  /** Cursor CLI mode override: agent | ask | plan */
+  mode?: string;
   max_tokens: number;
   messages: AnthropicMessageParam[];
   system?: string | Array<{ type?: string; text?: string }>;

--- a/src/lib/config.test.ts
+++ b/src/lib/config.test.ts
@@ -18,6 +18,7 @@ describe("loadBridgeConfig", () => {
     expect(config.mode).toBe("ask");
     expect(config.workspace).toBe("/workspace");
     expect(config.chatOnlyWorkspace).toBe(true);
+    expect(config.chatOnlyWorkspaceExplicit).toBe(false);
     expect(config.sessionsLogPath).toBe(path.join("/workspace", "sessions.log"));
     expect(config.winCmdlineMax).toBe(30_000);
   });
@@ -55,6 +56,7 @@ describe("loadBridgeConfig", () => {
     expect(config.workspace).toContain("my-workspace");
     expect(config.timeoutMs).toBe(60000);
     expect(config.chatOnlyWorkspace).toBe(false);
+    expect(config.chatOnlyWorkspaceExplicit).toBe(true);
     expect(config.verbose).toBe(true);
     expect(config.tlsCertPath).toBe(
       path.resolve("/tmp/project", "./certs/test.crt"),
@@ -101,5 +103,40 @@ describe("loadBridgeConfig", () => {
     });
 
     expect(config.host).toBe("0.0.0.0");
+  });
+
+  it("reads CURSOR_BRIDGE_MODE from env", () => {
+    const config = loadBridgeConfig({
+      env: { CURSOR_BRIDGE_MODE: "agent", CURSOR_AGENT_BIN: "agent" },
+      cwd: "/workspace",
+    });
+    expect(config.mode).toBe("agent");
+  });
+
+  it("prefers env mode over CLI opts.mode", () => {
+    const config = loadBridgeConfig({
+      env: { CURSOR_BRIDGE_MODE: "plan", CURSOR_AGENT_BIN: "agent" },
+      mode: "agent",
+      cwd: "/workspace",
+    });
+    expect(config.mode).toBe("plan");
+  });
+
+  it("uses opts.mode when env unset", () => {
+    const config = loadBridgeConfig({
+      env: { CURSOR_AGENT_BIN: "agent" },
+      mode: "agent",
+      cwd: "/workspace",
+    });
+    expect(config.mode).toBe("agent");
+  });
+
+  it("throws on invalid CURSOR_BRIDGE_MODE", () => {
+    expect(() =>
+      loadBridgeConfig({
+        env: { CURSOR_BRIDGE_MODE: "bogus", CURSOR_AGENT_BIN: "agent" },
+        cwd: "/workspace",
+      }),
+    ).toThrow(/CURSOR_BRIDGE_MODE/);
   });
 });

--- a/src/lib/config.ts
+++ b/src/lib/config.ts
@@ -1,6 +1,7 @@
+import type { CursorExecutionMode } from "./execution-mode.js";
 import { loadEnvConfig, resolveAgentCommand, type EnvOptions } from "./env.js";
 
-export type CursorExecutionMode = "agent" | "ask" | "plan";
+export type { CursorExecutionMode } from "./execution-mode.js";
 
 export type BridgeConfig = {
   agentBin: string;
@@ -28,6 +29,8 @@ export type BridgeConfig = {
   sessionsLogPath: string;
   /** When true (default), run CLI in an empty temp dir so it cannot read or write the real project. Pure chat only. */
   chatOnlyWorkspace: boolean;
+  /** True when CURSOR_BRIDGE_CHAT_ONLY_WORKSPACE was set in the environment (any value). */
+  chatOnlyWorkspaceExplicit: boolean;
   /** When true, print full request/response content to stdout for each completion. */
   verbose: boolean;
   /** When true, enable Cursor Max Mode (larger context, more tool calls) via cli-config.json preflight. */
@@ -72,7 +75,7 @@ export function loadBridgeConfig(opts: EnvOptions = {}): BridgeConfig {
     port: env.port,
     requiredKey: env.requiredKey,
     defaultModel: env.defaultModel,
-    mode: "ask", // proxy is chat-only; CURSOR_BRIDGE_MODE is ignored
+    mode: env.mode ?? opts.mode ?? "ask",
     force: env.force,
     approveMcps: env.approveMcps,
     strictModel: env.strictModel,
@@ -82,6 +85,7 @@ export function loadBridgeConfig(opts: EnvOptions = {}): BridgeConfig {
     tlsKeyPath: env.tlsKeyPath,
     sessionsLogPath: env.sessionsLogPath,
     chatOnlyWorkspace: env.chatOnlyWorkspace,
+    chatOnlyWorkspaceExplicit: env.chatOnlyWorkspaceExplicit,
     verbose: env.verbose,
     maxMode: env.maxMode,
     promptViaStdin: env.promptViaStdin,

--- a/src/lib/env.test.ts
+++ b/src/lib/env.test.ts
@@ -20,6 +20,8 @@ describe("loadEnvConfig", () => {
     expect(loaded.workspace).toBe("/workspace");
     expect(loaded.sessionsLogPath).toBe(path.join("/workspace", "sessions.log"));
     expect(loaded.chatOnlyWorkspace).toBe(true);
+    expect(loaded.chatOnlyWorkspaceExplicit).toBe(false);
+    expect(loaded.mode).toBeUndefined();
     expect(loaded.verbose).toBe(false);
     expect(loaded.commandShell).toBe("cmd.exe");
     expect(loaded.maxMode).toBe(false);
@@ -64,6 +66,25 @@ describe("loadEnvConfig", () => {
     expect(loaded.strictModel).toBe(false);
     expect(loaded.timeoutMs).toBe(60000);
     expect(loaded.defaultModel).toBe("claude-3-opus");
+  });
+
+  it("parses CURSOR_BRIDGE_MODE and marks chat-only env as explicit", () => {
+    const loaded = loadEnvConfig({
+      env: {
+        CURSOR_BRIDGE_MODE: "plan",
+        CURSOR_BRIDGE_CHAT_ONLY_WORKSPACE: "false",
+      },
+      cwd: "/w",
+    });
+    expect(loaded.mode).toBe("plan");
+    expect(loaded.chatOnlyWorkspaceExplicit).toBe(true);
+    expect(loaded.chatOnlyWorkspace).toBe(false);
+  });
+
+  it("throws on invalid CURSOR_BRIDGE_MODE", () => {
+    expect(() =>
+      loadEnvConfig({ env: { CURSOR_BRIDGE_MODE: "nope" }, cwd: "/w" }),
+    ).toThrow(/CURSOR_BRIDGE_MODE/);
   });
 
   it("resolves workspace and explicit paths from cwd", () => {

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -1,6 +1,9 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 
+import type { CursorExecutionMode } from "./execution-mode.js";
+import { tryParseExecutionModeEnv } from "./execution-mode.js";
+
 export type EnvSource = Record<string, string | undefined>;
 
 export type EnvOptions = {
@@ -8,6 +11,8 @@ export type EnvOptions = {
   env?: EnvSource;
   cwd?: string;
   platform?: NodeJS.Platform;
+  /** CLI `--mode` (overridden by CURSOR_BRIDGE_MODE when set). */
+  mode?: CursorExecutionMode;
 };
 
 export type LoadedEnv = {
@@ -28,6 +33,9 @@ export type LoadedEnv = {
   tlsKeyPath?: string;
   sessionsLogPath: string;
   chatOnlyWorkspace: boolean;
+  /** True when CURSOR_BRIDGE_CHAT_ONLY_WORKSPACE key exists in env. */
+  chatOnlyWorkspaceExplicit: boolean;
+  mode?: CursorExecutionMode;
   verbose: boolean;
   /** When true, set maxMode in cli-config.json before each run (larger context, more tools). */
   maxMode: boolean;
@@ -232,6 +240,13 @@ export function loadEnvConfig(opts: EnvOptions = {}): LoadedEnv {
     Math.max(4096, Number.isFinite(winCmdlineRaw) ? winCmdlineRaw : 30_000),
   );
 
+  const chatOnlyWorkspaceExplicit = Object.prototype.hasOwnProperty.call(
+    env,
+    "CURSOR_BRIDGE_CHAT_ONLY_WORKSPACE",
+  );
+
+  const mode = tryParseExecutionModeEnv(firstDefined(env, ["CURSOR_BRIDGE_MODE"]));
+
   return {
     agentBin:
       envString(env, [
@@ -264,11 +279,13 @@ export function loadEnvConfig(opts: EnvOptions = {}): LoadedEnv {
       cwd,
     ),
     sessionsLogPath,
+    chatOnlyWorkspaceExplicit,
     chatOnlyWorkspace: envBool(
       env,
       ["CURSOR_BRIDGE_CHAT_ONLY_WORKSPACE"],
       true,
     ),
+    mode,
     verbose: envBool(env, ["CURSOR_BRIDGE_VERBOSE"], false),
     maxMode: envBool(env, ["CURSOR_BRIDGE_MAX_MODE"], false),
     promptViaStdin: envBool(env, ["CURSOR_BRIDGE_PROMPT_VIA_STDIN"], false),

--- a/src/lib/execution-mode.ts
+++ b/src/lib/execution-mode.ts
@@ -1,0 +1,32 @@
+export type CursorExecutionMode = "agent" | "ask" | "plan";
+
+const MODES = new Set<string>(["agent", "ask", "plan"]);
+
+/**
+ * Parse CURSOR_BRIDGE_MODE; undefined if unset/blank; throws if invalid.
+ */
+export function tryParseExecutionModeEnv(
+  raw: string | undefined,
+): CursorExecutionMode | undefined {
+  if (raw == null) return undefined;
+  const t = raw.trim().toLowerCase();
+  if (!t) return undefined;
+  if (!MODES.has(t)) {
+    throw new Error("CURSOR_BRIDGE_MODE must be agent, ask, or plan");
+  }
+  return t as CursorExecutionMode;
+}
+
+export function parseExecutionModeFromRequest(
+  raw: string,
+  source: string,
+): CursorExecutionMode {
+  const t = raw.trim().toLowerCase();
+  if (!t) {
+    throw new Error(`${source}: empty mode`);
+  }
+  if (!MODES.has(t)) {
+    throw new Error(`${source}: invalid mode (use agent, ask, or plan)`);
+  }
+  return t as CursorExecutionMode;
+}

--- a/src/lib/handlers/anthropic-messages.ts
+++ b/src/lib/handlers/anthropic-messages.ts
@@ -7,6 +7,7 @@ import { buildAgentFixedArgs } from "../agent-cmd-args.js";
 import { runAgentStream, runAgentSync } from "../agent-runner.js";
 import { createStreamParser } from "../cli-stream-parser.js";
 import type { BridgeConfig } from "../config.js";
+import type { CursorExecutionMode } from "../execution-mode.js";
 import type { ModelCacheRef } from "./models.js";
 import { getCachedCursorModels } from "./models.js";
 import { json, writeSseHeaders } from "../http.js";
@@ -22,6 +23,7 @@ import {
   type TrafficMessage,
 } from "../request-log.js";
 import { rememberResolvedModel, resolveModel } from "../resolve-model.js";
+import { resolveRequestMode } from "../resolve-mode.js";
 import { resolveWorkspace } from "../workspace.js";
 import { sanitizeMessages, sanitizeSystem } from "../sanitize.js";
 import {
@@ -128,11 +130,35 @@ export async function handleAnthropicMessages(
     !!body.stream,
   );
 
+  let mode: CursorExecutionMode;
+  try {
+    mode = resolveRequestMode(
+      config,
+      req.headers["x-cursor-mode"],
+      body.mode,
+    );
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "Invalid mode";
+    json(res, 400, {
+      error: {
+        type: "invalid_request_error",
+        message: msg,
+        code: "invalid_mode",
+      },
+    });
+    return;
+  }
+
+  const effectiveChatOnly =
+    mode === "ask"
+      ? config.chatOnlyWorkspace
+      : config.chatOnlyWorkspaceExplicit && config.chatOnlyWorkspace;
+
   const headerWs = req.headers["x-cursor-workspace"];
   let workspaceDir: string;
   let tempDir: string | undefined;
   try {
-    const ws = resolveWorkspace(config, headerWs);
+    const ws = resolveWorkspace(config, headerWs, effectiveChatOnly);
     workspaceDir = ws.workspaceDir;
     tempDir = ws.tempDir;
   } catch (e) {
@@ -148,6 +174,8 @@ export async function handleAnthropicMessages(
     workspaceDir,
     cursorModel,
     !!body.stream,
+    mode,
+    effectiveChatOnly,
   );
   const fit = fitPromptToWinCmdline(config.agentBin, fixedArgs, prompt, {
     maxCmdline: config.winCmdlineMax,
@@ -217,6 +245,7 @@ export async function handleAnthropicMessages(
       runAgentStream(
         config,
         workspaceDir,
+        effectiveChatOnly,
         cmdArgs,
         (chunk) => {
           accumulated += chunk;
@@ -327,6 +356,7 @@ export async function handleAnthropicMessages(
     runAgentStream(
       config,
       workspaceDir,
+      effectiveChatOnly,
       cmdArgs,
       parseLine,
       tempDir,
@@ -385,6 +415,7 @@ export async function handleAnthropicMessages(
   const out = await runAgentSync(
     config,
     workspaceDir,
+    effectiveChatOnly,
     cmdArgs,
     tempDir,
     promptForAgent,

--- a/src/lib/handlers/chat-completions.ts
+++ b/src/lib/handlers/chat-completions.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 import * as http from "node:http";
 
 import type { BridgeConfig } from "../config.js";
+import type { CursorExecutionMode } from "../execution-mode.js";
 import type { ModelCacheRef } from "./models.js";
 import { getCachedCursorModels } from "./models.js";
 import { buildAgentFixedArgs } from "../agent-cmd-args.js";
@@ -25,6 +26,7 @@ import {
   type TrafficMessage,
 } from "../request-log.js";
 import { rememberResolvedModel, resolveModel } from "../resolve-model.js";
+import { resolveRequestMode } from "../resolve-mode.js";
 import { resolveWorkspace } from "../workspace.js";
 import { sanitizeMessages } from "../sanitize.js";
 import {
@@ -106,11 +108,29 @@ export async function handleChatCompletions(
     !!body.stream,
   );
 
+  let mode: CursorExecutionMode;
+  try {
+    mode = resolveRequestMode(
+      config,
+      req.headers["x-cursor-mode"],
+      body.mode,
+    );
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : "Invalid mode";
+    json(res, 400, { error: { message: msg, code: "invalid_mode" } });
+    return;
+  }
+
+  const effectiveChatOnly =
+    mode === "ask"
+      ? config.chatOnlyWorkspace
+      : config.chatOnlyWorkspaceExplicit && config.chatOnlyWorkspace;
+
   const headerWs = req.headers["x-cursor-workspace"];
   let workspaceDir: string;
   let tempDir: string | undefined;
   try {
-    const ws = resolveWorkspace(config, headerWs);
+    const ws = resolveWorkspace(config, headerWs, effectiveChatOnly);
     workspaceDir = ws.workspaceDir;
     tempDir = ws.tempDir;
   } catch (e) {
@@ -124,6 +144,8 @@ export async function handleChatCompletions(
     workspaceDir,
     cursorModel,
     !!body.stream,
+    mode,
+    effectiveChatOnly,
   );
   const fit = fitPromptToWinCmdline(config.agentBin, fixedArgs, prompt, {
     maxCmdline: config.winCmdlineMax,
@@ -174,6 +196,7 @@ export async function handleChatCompletions(
       runAgentStream(
         config,
         workspaceDir,
+        effectiveChatOnly,
         cmdArgs,
         (chunk) => {
           accumulated += chunk;
@@ -328,6 +351,7 @@ export async function handleChatCompletions(
     runAgentStream(
       config,
       workspaceDir,
+      effectiveChatOnly,
       cmdArgs,
       parseLine,
       tempDir,
@@ -386,6 +410,7 @@ export async function handleChatCompletions(
   const out = await runAgentSync(
     config,
     workspaceDir,
+    effectiveChatOnly,
     cmdArgs,
     tempDir,
     promptForAgent,

--- a/src/lib/handlers/health.ts
+++ b/src/lib/handlers/health.ts
@@ -13,11 +13,13 @@ export function handleHealth(
   opts: HealthHandlerOpts,
 ): void {
   const { version, config } = opts;
+  // mode: default for Cursor CLI; clients may override per request (body.mode, X-Cursor-Mode).
   json(res, 200, {
     ok: true,
     version,
     workspace: config.workspace,
     mode: config.mode,
+    perRequestMode: true,
     defaultModel: config.defaultModel,
     force: config.force,
     approveMcps: config.approveMcps,

--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -1,5 +1,7 @@
 export type OpenAiChatCompletionRequest = {
   model?: string;
+  /** Cursor CLI mode override: agent | ask | plan */
+  mode?: string;
   messages: any[];
   stream?: boolean;
   tools?: any[];

--- a/src/lib/resolve-mode.test.ts
+++ b/src/lib/resolve-mode.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from "vitest";
+
+import type { BridgeConfig } from "./config.js";
+import { resolveRequestMode } from "./resolve-mode.js";
+
+function base(overrides: Partial<BridgeConfig> = {}): BridgeConfig {
+  return {
+    agentBin: "agent",
+    acpCommand: "agent",
+    acpArgs: ["acp"],
+    acpEnv: {},
+    host: "127.0.0.1",
+    port: 8765,
+    defaultModel: "default",
+    mode: "ask",
+    force: false,
+    approveMcps: false,
+    strictModel: true,
+    workspace: "/w",
+    timeoutMs: 30_000,
+    sessionsLogPath: "/tmp/s.log",
+    chatOnlyWorkspace: true,
+    chatOnlyWorkspaceExplicit: false,
+    verbose: false,
+    maxMode: false,
+    promptViaStdin: false,
+    useAcp: false,
+    acpSkipAuthenticate: true,
+    acpRawDebug: false,
+    configDirs: [],
+    multiPort: false,
+    winCmdlineMax: 30_000,
+    ...overrides,
+  };
+}
+
+describe("resolveRequestMode", () => {
+  it("prefers body.mode over header and config", () => {
+    expect(
+      resolveRequestMode(base({ mode: "plan" }), "agent", "ask"),
+    ).toBe("ask");
+  });
+
+  it("uses header when body absent", () => {
+    expect(resolveRequestMode(base({ mode: "ask" }), "plan", undefined)).toBe(
+      "plan",
+    );
+  });
+
+  it("falls back to config.mode", () => {
+    expect(
+      resolveRequestMode(base({ mode: "agent" }), undefined, undefined),
+    ).toBe("agent");
+  });
+
+  it("throws on invalid body.mode", () => {
+    expect(() =>
+      resolveRequestMode(base(), undefined, "nope"),
+    ).toThrow(/invalid mode/);
+  });
+
+  it("throws when body.mode is not a string", () => {
+    expect(() =>
+      resolveRequestMode(base(), undefined, 1),
+    ).toThrow(/must be a string/);
+  });
+});

--- a/src/lib/resolve-mode.ts
+++ b/src/lib/resolve-mode.ts
@@ -1,0 +1,25 @@
+import type { BridgeConfig } from "./config.js";
+import {
+  parseExecutionModeFromRequest,
+  type CursorExecutionMode,
+} from "./execution-mode.js";
+
+export function resolveRequestMode(
+  config: BridgeConfig,
+  headerMode: string | string[] | undefined,
+  bodyMode: unknown,
+): CursorExecutionMode {
+  if (bodyMode !== undefined && bodyMode !== null) {
+    if (typeof bodyMode !== "string") {
+      throw new Error("Request body mode must be a string");
+    }
+    if (bodyMode.trim()) {
+      return parseExecutionModeFromRequest(bodyMode, "body.mode");
+    }
+  }
+  const h = Array.isArray(headerMode) ? headerMode[0] : headerMode;
+  if (typeof h === "string" && h.trim()) {
+    return parseExecutionModeFromRequest(h, "X-Cursor-Mode header");
+  }
+  return config.mode;
+}

--- a/src/lib/resolve-model.test.ts
+++ b/src/lib/resolve-model.test.ts
@@ -20,6 +20,7 @@ function config(overrides: Partial<BridgeConfig> = {}): BridgeConfig {
     timeoutMs: 30_000,
     sessionsLogPath: "/tmp/test.log",
     chatOnlyWorkspace: true,
+    chatOnlyWorkspaceExplicit: false,
     verbose: false,
     maxMode: false,
     promptViaStdin: false,

--- a/src/lib/server.test.ts
+++ b/src/lib/server.test.ts
@@ -63,6 +63,7 @@ function createTestConfig(overrides: Partial<BridgeConfig> = {}): BridgeConfig {
     timeoutMs: 30_000,
     sessionsLogPath: tmpLogPath,
     chatOnlyWorkspace: true,
+    chatOnlyWorkspaceExplicit: false,
     verbose: false,
     maxMode: false,
     promptViaStdin: false,
@@ -137,6 +138,8 @@ describe("startBridgeServer", () => {
     expect(data.ok).toBe(true);
     expect(data.version).toBe("1.0.0");
     expect(data.defaultModel).toBe("default");
+    expect(data.mode).toBe("ask");
+    expect(data.perRequestMode).toBe(true);
   });
 
   it("responds 200 on GET /v1/models", async () => {
@@ -275,6 +278,32 @@ describe("startBridgeServer", () => {
     expect(status).toBe(200);
     const data = JSON.parse(body);
     expect(data.model).toBe("default");
+  });
+
+  it("returns 400 for invalid body.mode on POST /v1/chat/completions", async () => {
+    servers = startBridgeServer({
+      version: "1.0.0",
+      config: createTestConfig(),
+    });
+    await new Promise<void>((resolve) =>
+      servers[0].on("listening", () => resolve()),
+    );
+
+    const { status, body } = await fetchServer(
+      servers[0],
+      "/v1/chat/completions",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          model: "claude-3-opus",
+          mode: "bogus",
+          messages: [{ role: "user", content: "Hi" }],
+        }),
+      },
+    );
+    expect(status).toBe(400);
+    const data = JSON.parse(body);
+    expect(data.error.code).toBe("invalid_mode");
   });
 
   it("should spawn multiple servers when multiPort is true", async () => {

--- a/src/lib/workspace.test.ts
+++ b/src/lib/workspace.test.ts
@@ -22,6 +22,7 @@ function baseConfig(overrides: Partial<BridgeConfig> = {}): BridgeConfig {
     timeoutMs: 300_000,
     sessionsLogPath: "/tmp/sessions.log",
     chatOnlyWorkspace: false,
+    chatOnlyWorkspaceExplicit: false,
     verbose: false,
     maxMode: false,
     promptViaStdin: false,
@@ -52,6 +53,21 @@ describe("getChatOnlyEnvOverrides", () => {
 });
 
 describe("resolveWorkspace", () => {
+  it("uses temp dir when chat-only is effective", () => {
+    const cfg = baseConfig({ chatOnlyWorkspace: true });
+    const { workspaceDir, tempDir } = resolveWorkspace(cfg, undefined);
+    expect(tempDir).toBeDefined();
+    expect(workspaceDir).toContain("cursor-proxy-");
+  });
+
+  it("uses real workspace when effectiveChatOnly is false despite config.chatOnlyWorkspace", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "ws-real-"));
+    const cfg = baseConfig({ workspace: tmp, chatOnlyWorkspace: true });
+    const { workspaceDir, tempDir } = resolveWorkspace(cfg, undefined, false);
+    expect(tempDir).toBeUndefined();
+    expect(fs.realpathSync(workspaceDir)).toBe(fs.realpathSync(tmp));
+  });
+
   it("rejects X-Cursor-Workspace outside configured base", () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "ws-base-"));
     const outside = fs.mkdtempSync(path.join(os.tmpdir(), "ws-out-"));

--- a/src/lib/workspace.ts
+++ b/src/lib/workspace.ts
@@ -50,8 +50,13 @@ export function getChatOnlyEnvOverrides(
 export function resolveWorkspace(
   config: BridgeConfig,
   workspaceHeader?: string | string[] | null,
+  effectiveChatOnly?: boolean,
 ): WorkspaceResult {
-  if (config.chatOnlyWorkspace) {
+  const useChatOnly =
+    effectiveChatOnly !== undefined
+      ? effectiveChatOnly
+      : config.chatOnlyWorkspace;
+  if (useChatOnly) {
     const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), "cursor-proxy-"));
     const cursorDir = path.join(tempDir, ".cursor");
     fs.mkdirSync(cursorDir, { recursive: true });


### PR DESCRIPTION
## Summary
- bump package version to `1.0.0` (`package.json` + `package-lock.json`) for first major release
- ship mode-override feature (`--mode`, `CURSOR_BRIDGE_MODE`, `X-Cursor-Mode`, body `mode`) with request precedence and workspace behavior
- add tests/docs updates needed for release confidence and operator guidance

## Test plan
- [x] `npm test`
- [x] `npm run build`
- [ ] Create GitHub release `v1.0.0` from this merge commit
- [ ] Publish npm package: `npm publish`
- [ ] Verify install/version: `npm view cursor-api-proxy version`


Made with [Cursor](https://cursor.com)