### PR TITLE
fix: omit --mode agent (cursor-agent rejects it as default)

### DIFF
--- a/src/lib/agent-cmd-args.test.ts
+++ b/src/lib/agent-cmd-args.test.ts
@@ -35,7 +35,7 @@ function cfg(overrides: Partial<BridgeConfig> = {}): BridgeConfig {
 }
 
 describe("buildAgentFixedArgs", () => {
-  it("passes --mode and --trust when effectiveChatOnly", () => {
+  it("omits --mode when mode is agent (cursor-agent default)", () => {
     const args = buildAgentFixedArgs(
       cfg(),
       "/ws",
@@ -44,9 +44,35 @@ describe("buildAgentFixedArgs", () => {
       "agent",
       true,
     );
-    expect(args).toContain("--mode");
-    expect(args[args.indexOf("--mode") + 1]).toBe("agent");
+    // cursor-agent rejects `--mode agent`; agent is its default behavior.
+    expect(args).not.toContain("--mode");
     expect(args).toContain("--trust");
+  });
+
+  it("passes --mode ask when mode is ask", () => {
+    const args = buildAgentFixedArgs(
+      cfg(),
+      "/ws",
+      "gpt-5",
+      false,
+      "ask",
+      true,
+    );
+    expect(args).toContain("--mode");
+    expect(args[args.indexOf("--mode") + 1]).toBe("ask");
+  });
+
+  it("passes --mode plan when mode is plan", () => {
+    const args = buildAgentFixedArgs(
+      cfg(),
+      "/ws",
+      "gpt-5",
+      false,
+      "plan",
+      true,
+    );
+    expect(args).toContain("--mode");
+    expect(args[args.indexOf("--mode") + 1]).toBe("plan");
   });
 
   it("omits --trust when not effectiveChatOnly", () => {

--- a/src/lib/agent-cmd-args.ts
+++ b/src/lib/agent-cmd-args.ts
@@ -16,7 +16,11 @@ export function buildAgentFixedArgs(
   if (config.approveMcps) args.push("--approve-mcps");
   if (config.force) args.push("--force");
   if (effectiveChatOnly) args.push("--trust");
-  args.push("--mode", mode);
+  // cursor-agent only accepts --mode plan|ask; agent mode is the default
+  // and rejects --mode agent with "argument 'agent' is invalid".
+  if (mode !== "agent") {
+    args.push("--mode", mode);
+  }
   args.push("--workspace", workspaceDir);
   args.push("--model", model);
   if (stream) {

--- a/src/lib/agent-runner.ts
+++ b/src/lib/agent-runner.ts
@@ -28,6 +28,8 @@ function acpArgsWithModel(acpArgs: string[], model: string): string[] {
 function acpArgsWithMode(acpArgs: string[], mode: CursorExecutionMode): string[] {
   const i = acpArgs.indexOf("acp");
   if (i === -1) return acpArgs;
+  // cursor-agent only accepts --mode plan|ask; agent mode is the default.
+  if (mode === "agent") return acpArgs;
   return [...acpArgs.slice(0, i + 1), "--mode", mode, ...acpArgs.slice(i + 1)];
 }
 


### PR DESCRIPTION
## Summary

`cursor-agent`'s `--mode` flag only accepts `plan` or `ask`. The proxy currently passes `"--mode", "agent"` for every request whose effective mode resolves to `agent`, which makes the CLI exit `1` with:

```
error: option '--mode <mode>' argument 'agent' is invalid. Allowed choices are plan, ask.
```

Agent is `cursor-agent`'s default behavior when no `--mode` is provided, so the fix is simply to omit the flag in that case.

This affects every integration that doesn't explicitly set `body.mode` (e.g. an Anthropic Messages client speaking `/v1/messages` without setting `mode`), and any user who sets `CURSOR_BRIDGE_MODE=agent`.

## Changes

- `src/lib/agent-cmd-args.ts` — skip `--mode` when `mode === "agent"`.
- `src/lib/agent-runner.ts` — same skip in `acpArgsWithMode` for the ACP path.
- `src/lib/agent-cmd-args.test.ts` — replace the assertion that `--mode agent` is passed; add coverage for `ask` and `plan` still emitting the flag.

## Test plan

- `npm test` — all 199 tests pass.
- End-to-end against `cursor-agent` 2026.* (Anthropic Messages client):
  - **Agent mode**: `POST /v1/messages` with `"mode":"agent"` asking the agent to create `/tmp/test.txt` — file is now created and assistant replies `done.` (was: `500 cursor_cli_error` before the fix).
  - **Plan mode**: still read-only, no file created (regression-free).
  - **Ask mode**: unchanged (regression-free).

## Notes

I noticed plan mode currently returns a `200` with empty text because the proxy doesn't translate `tool_call` stream events into Anthropic content blocks. That's a separate, larger fix and is left out of this PR to keep the diff focused.

Made with [Cursor](https://cursor.com)