### PR TITLE
fix(cli): resolve agent command in login to fix spawn EINVAL on Windows

### DIFF
--- a/src/cli/login.ts
+++ b/src/cli/login.ts
@@ -3,7 +3,7 @@ import path from "node:path";
 import { spawn } from "node:child_process";
 import { launch as launchChrome } from "chrome-launcher";
 
-import { loadEnvConfig } from "../lib/env.js";
+import { loadEnvConfig, resolveAgentCommand } from "../lib/env.js";
 import { ACCOUNTS_DIR } from "./constants.js";
 import { readKeychainToken, writeCachedToken } from "./usage.js";
 
@@ -84,13 +84,15 @@ export async function handleLogin(
       }
     };
 
-    const child = spawn(envCfg.agentBin, ["login"], {
+    const resolved = resolveAgentCommand(envCfg.agentBin, ["login"]);
+    const child = spawn(resolved.command, resolved.args, {
       stdio: ["inherit", "pipe", "pipe"],
       env: {
-        ...process.env,
+        ...resolved.env,
         CURSOR_CONFIG_DIR: configDir,
         NO_OPEN_BROWSER: "1",
       },
+      windowsVerbatimArguments: resolved.windowsVerbatimArguments,
     });
 
     // Remove all signal handlers once the child exits (success or failure)


### PR DESCRIPTION
## Summary

On Windows with Node 20.12+ / 21.7+ / 22+ / 24, `cursor-api-proxy login`
crashes with `spawn EINVAL`. Node refuses to spawn `.cmd` files directly
without `shell: true` (CVE-2024-27980 mitigation), and `src/cli/login.ts`
was calling `spawn(envCfg.agentBin, ["login"], ...)` with `agentBin`
pointing at `agent.cmd`.

The chat path (`src/lib/process.ts`) already routes through
`resolveAgentCommand`, which on Windows resolves `agent.cmd` to
`node.exe + index.js` from the versioned `cursor-agent` layout. This
PR applies the same resolution in the login subcommand.

## Change

- `src/cli/login.ts`: call `resolveAgentCommand(envCfg.agentBin, ["login"])`
  before `spawn`, then use `resolved.command`, `resolved.args`,
  `resolved.env` (merged with `CURSOR_CONFIG_DIR` and `NO_OPEN_BROWSER`),
  and `resolved.windowsVerbatimArguments`.

## Non-Windows impact

`resolveAgentCommand` is a passthrough on non-win32 platforms
(`src/lib/env.ts`), so the resulting `spawn` call is byte-for-byte
equivalent to the previous code on macOS / Linux:

| field | before | after (non-win32) |
| --- | --- | --- |
| command | `envCfg.agentBin` | `envCfg.agentBin` |
| args | `["login"]` | `["login"]` |
| env | `{...process.env, CURSOR_CONFIG_DIR, NO_OPEN_BROWSER}` | `{...process.env, CURSOR_CONFIG_DIR, NO_OPEN_BROWSER}` |
| windowsVerbatimArguments | omitted | `undefined` |

## Test plan

- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test` — 198/199 passing. The one failure (`src/lib/workspace.test.ts`) is pre-existing on Windows (test hardcodes POSIX `/tmp/...` path separators); verified by running the suite with `git stash` applied.
- [x] Manually: `npm start` on Windows with `CURSOR_AGENT_BIN=...\agent.cmd`, `CURSOR_BRIDGE_CHAT_ONLY_WORKSPACE=false`, `CURSOR_BRIDGE_FORCE=true` — `/v1/chat/completions` returns expected response (unaffected by this change; same `resolveAgentCommand` path was already working there).
- [x] Manual login flow on Windows (reviewer to confirm; smoke test from this branch reaches the `agent login` URL print step instead of crashing on spawn).
- [ ] Non-Windows: no behavior change expected; CI / reviewer to confirm.
