### PR TITLE
Fix Windows cmd agent script resolution

### DIFF
--- a/src/lib/env.test.ts
+++ b/src/lib/env.test.ts
@@ -406,6 +406,36 @@ describe("resolveAgentCommand", () => {
     expect(command.windowsVerbatimArguments).toBeUndefined();
   });
 
+  it("uses CURSOR_AGENT_SCRIPT .cmd as a shim when CURSOR_AGENT_NODE is set", () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), "cursor-agent-"));
+    try {
+      const agentCmd = path.join(tmp, "cursor-agent.CMD");
+      const versionDir = path.join(tmp, "versions", "2026.03.26-abcdef0");
+      fs.mkdirSync(versionDir, { recursive: true });
+      fs.writeFileSync(agentCmd, "@echo off\r\n");
+      fs.writeFileSync(path.join(versionDir, "index.js"), "");
+
+      const command = resolveAgentCommand("agent.cmd", ["--print", "hello"], {
+        platform: "win32",
+        env: {
+          CURSOR_AGENT_NODE: "D:\\Applications\\nodejs\\node.exe",
+          CURSOR_AGENT_SCRIPT: agentCmd,
+        },
+      });
+
+      expect(command.command).toBe("D:\\Applications\\nodejs\\node.exe");
+      expect(command.args).toEqual([
+        path.join(versionDir, "index.js"),
+        "--print",
+        "hello",
+      ]);
+      expect(command.env.CURSOR_INVOKED_AS).toBe("agent.cmd");
+      expect(command.windowsVerbatimArguments).toBeUndefined();
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  });
+
   it("uses COMSPEC for .cmd invocations on Windows when direct node launch is unavailable", () => {
     const command = resolveAgentCommand(
       "C:\\cursor\\agent.cmd",

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -181,6 +181,69 @@ function findLatestVersionDir(dir: string): string | undefined {
   return path.join(versionsDir, versionDirs[0]!.name);
 }
 
+function configDirFromAgentDir(dir: string): string | undefined {
+  const configDir = path.join(dir, "..", "data", "config");
+  return fs.existsSync(path.join(configDir, "cli-config.json"))
+    ? configDir
+    : undefined;
+}
+
+function resolveCmdShim(
+  cmdPath: string,
+  args: string[],
+  env: EnvSource,
+  nodeOverride?: string,
+): AgentCommand | undefined {
+  const dir = path.dirname(cmdPath);
+  const nodeBin = path.join(dir, "node.exe");
+  const script = path.join(dir, "index.js");
+  if (fs.existsSync(script) && (nodeOverride || fs.existsSync(nodeBin))) {
+    return {
+      command: nodeOverride ?? nodeBin,
+      args: [script, ...args],
+      env: { ...env, CURSOR_INVOKED_AS: "agent.cmd" },
+      agentScriptPath: script,
+      configDir: configDirFromAgentDir(dir),
+    };
+  }
+  const versionDir = findLatestVersionDir(dir);
+  if (versionDir) {
+    const versionNode = path.join(versionDir, "node.exe");
+    const versionScript = path.join(versionDir, "index.js");
+    if (
+      fs.existsSync(versionScript) &&
+      (nodeOverride || fs.existsSync(versionNode))
+    ) {
+      return {
+        command: nodeOverride ?? versionNode,
+        args: [versionScript, ...args],
+        env: { ...env, CURSOR_INVOKED_AS: "agent.cmd" },
+        agentScriptPath: versionScript,
+        configDir: configDirFromAgentDir(dir),
+      };
+    }
+  }
+  return undefined;
+}
+
+function resolveCmdFallback(
+  cmd: string,
+  args: string[],
+  env: EnvSource,
+  shell: string,
+): AgentCommand {
+  const quotedArgs = args
+    .map((arg) => (arg.includes(" ") ? `"${arg}"` : arg))
+    .join(" ");
+  const cmdLine = `""${cmd}" ${quotedArgs}"`;
+  return {
+    command: shell,
+    args: ["/d", "/s", "/c", cmdLine],
+    env,
+    windowsVerbatimArguments: true,
+  };
+}
+
 /**
  * Auto-discovers configuration directories located inside ~/.cursor-api-proxy/accounts/
  */
@@ -344,64 +407,37 @@ export function resolveAgentCommand(
       const agentScriptPath = path.isAbsolute(loaded.agentScript)
         ? loaded.agentScript
         : path.resolve(cwd, loaded.agentScript);
+      if (/\.cmd$/i.test(loaded.agentScript)) {
+        const resolved = resolveCmdShim(
+          agentScriptPath,
+          args,
+          env,
+          loaded.agentNode,
+        );
+        if (resolved) return resolved;
+        return resolveCmdFallback(
+          loaded.agentScript,
+          args,
+          env,
+          loaded.commandShell,
+        );
+      }
       const agentDir = path.dirname(agentScriptPath);
-      const configDir = path.join(agentDir, "..", "data", "config");
       const out: AgentCommand = {
         command: loaded.agentNode,
         args: [loaded.agentScript, ...args],
         env: { ...env, CURSOR_INVOKED_AS: "agent.cmd" },
         agentScriptPath,
-        configDir: fs.existsSync(path.join(configDir, "cli-config.json"))
-          ? configDir
-          : undefined,
+        configDir: configDirFromAgentDir(agentDir),
       };
       return out;
     }
 
     if (/\.cmd$/i.test(cmd)) {
       const cmdResolved = path.resolve(cwd, cmd);
-      const dir = path.dirname(cmdResolved);
-      const nodeBin = path.join(dir, "node.exe");
-      const script = path.join(dir, "index.js");
-      if (fs.existsSync(nodeBin) && fs.existsSync(script)) {
-        const configDir = path.join(dir, "..", "data", "config");
-        return {
-          command: nodeBin,
-          args: [script, ...args],
-          env: { ...env, CURSOR_INVOKED_AS: "agent.cmd" },
-          agentScriptPath: script,
-          configDir: fs.existsSync(path.join(configDir, "cli-config.json"))
-            ? configDir
-            : undefined,
-        };
-      }
-      const versionDir = findLatestVersionDir(dir);
-      if (versionDir) {
-        const versionNode = path.join(versionDir, "node.exe");
-        const versionScript = path.join(versionDir, "index.js");
-        if (fs.existsSync(versionNode) && fs.existsSync(versionScript)) {
-          const configDir = path.join(dir, "..", "data", "config");
-          return {
-            command: versionNode,
-            args: [versionScript, ...args],
-            env: { ...env, CURSOR_INVOKED_AS: "agent.cmd" },
-            agentScriptPath: versionScript,
-            configDir: fs.existsSync(path.join(configDir, "cli-config.json"))
-              ? configDir
-              : undefined,
-          };
-        }
-      }
-      const quotedArgs = args
-        .map((arg) => (arg.includes(" ") ? `"${arg}"` : arg))
-        .join(" ");
-      const cmdLine = `""${cmd}" ${quotedArgs}"`;
-      return {
-        command: loaded.commandShell,
-        args: ["/d", "/s", "/c", cmdLine],
-        env,
-        windowsVerbatimArguments: true,
-      };
+      const resolved = resolveCmdShim(cmdResolved, args, env);
+      if (resolved) return resolved;
+      return resolveCmdFallback(cmd, args, env, loaded.commandShell);
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes Windows agent command resolution when both `CURSOR_AGENT_NODE` and `CURSOR_AGENT_SCRIPT` are set and the script points at a `.cmd` shim such as `cursor-agent.CMD`.

## Root Cause

The resolver previously treated `CURSOR_AGENT_SCRIPT` as a JavaScript entrypoint whenever `CURSOR_AGENT_NODE` was also set. That made the proxy run `node.exe cursor-agent.CMD`, causing Node to parse the batch wrapper and fail on `@echo off`.

## Changes

- Resolve `.cmd` agent scripts as shims by locating `index.js` next to the shim or in the latest `versions/YYYY.MM.DD-...` directory.
- Preserve the existing direct `.js` behavior for explicit JavaScript entrypoints.
- Keep the `cmd.exe` fallback when no direct JS entrypoint can be found.
- Add a regression test for `CURSOR_AGENT_NODE` plus `CURSOR_AGENT_SCRIPT=...cursor-agent.CMD`.

## Validation

- `npx vitest run src/lib/env.test.ts`
- `npm test`