### PR TITLE
fix: parse ANSI-colored agent --list-models output for /v1/models

### DIFF
--- a/src/lib/cursor-cli.test.ts
+++ b/src/lib/cursor-cli.test.ts
@@ -58,4 +58,18 @@ describe("parseCursorCliModels", () => {
     const models = parseCursorCliModels(output);
     expect(models).toEqual([{ id: "org/models/claude-3:latest", name: "Claude 3" }]);
   });
+
+  it("strips ANSI color codes from FORCE_COLOR output", () => {
+    const output = [
+      "\u001b[2mAvailable models\u001b[22m",
+      "",
+      "\u001b[36mauto\u001b[39m \u001b[2m- Auto\u001b[22m\u001b[2m (default)\u001b[22m",
+      "\u001b[36mgpt-5.3-codex\u001b[39m \u001b[2m- Codex 5.3\u001b[22m",
+    ].join("\n");
+    const models = parseCursorCliModels(output);
+    expect(models).toEqual([
+      { id: "auto", name: "Auto" },
+      { id: "gpt-5.3-codex", name: "Codex 5.3" },
+    ]);
+  });
 });

--- a/src/lib/cursor-cli.ts
+++ b/src/lib/cursor-cli.ts
@@ -4,8 +4,17 @@ import { run } from "./process.js";
 
 export type CursorCliModel = { id: string; name: string };
 
+/** Strip CSI / OSC ANSI sequences so colored CLI output still parses. */
+export function stripAnsi(text: string): string {
+  return text
+    .replace(/\u001b\[[0-9;?]*[ -/]*[@-~]/g, "")
+    .replace(/\u001b\][^\u0007]*(?:\u0007|\u001b\\)/g, "");
+}
+
 export function parseCursorCliModels(output: string): CursorCliModel[] {
-  const lines = output.split(/\r?\n/g).map((l) => l.trim());
+  const lines = stripAnsi(output)
+    .split(/\r?\n/g)
+    .map((l) => l.trim());
   const models: CursorCliModel[] = [];
 
   for (const line of lines) {
@@ -26,9 +35,16 @@ export async function listCursorCliModels(args: {
   agentBin: string;
   timeoutMs: number;
 }): Promise<CursorCliModel[]> {
+  // Parent shells (Cursor agent, CI) often set FORCE_COLOR=1; that paints
+  // `--list-models` with ANSI and used to yield an empty OpenAI model list.
   const list = await run(args.agentBin, ["--list-models"], {
     cwd: tmpdir(),
     timeoutMs: args.timeoutMs,
+    envOverrides: {
+      NO_COLOR: "1",
+      FORCE_COLOR: "0",
+      TERM: "dumb",
+    },
   });
 
   if (list.code !== 0) {

--- a/src/lib/handlers/models.ts
+++ b/src/lib/handlers/models.ts
@@ -35,7 +35,11 @@ export async function getCachedCursorModels(
         timeoutMs: 60_000,
       }).then(
         (models) => {
-          modelCacheRef.current = { at: Date.now(), models };
+          // Never cache an empty catalog — usually a parse/env glitch
+          // (e.g. colored CLI output) and would poison /v1/models for TTL.
+          if (models.length > 0) {
+            modelCacheRef.current = { at: Date.now(), models };
+          }
           modelCacheRef.inflight = undefined;
           return models;
         },


### PR DESCRIPTION
## Summary

- Fix `GET /v1/models` returning an empty catalog when the proxy inherits `FORCE_COLOR=1` from the parent shell (e.g. Cursor agent sessions)
- Strip ANSI escape codes before parsing `agent --list-models` output
- Force `NO_COLOR=1` / `FORCE_COLOR=0` / `TERM=dumb` when spawning `--list-models`
- Skip caching empty model catalogs so a transient parse failure does not poison `/v1/models` for 5 minutes

Fixes #28

## Test plan

- [x] `npm test -- --run src/lib/cursor-cli.test.ts`
- [x] `npm run build`
- [x] Repro: `FORCE_COLOR=1` raw output parsed to 0 models before fix; after fix `listCursorCliModels()` returns 153 models
- [x] `curl http://127.0.0.1:8765/v1/models` returns non-empty `data` after restart

Made with [Cursor](https://cursor.com)