### PR TITLE
fix: keep prompt out of argv when promptViaStdin/ACP is enabled (Linux spawn E2BIG)

### DIFF
--- a/src/lib/handlers/anthropic-messages.ts
+++ b/src/lib/handlers/anthropic-messages.ts
@@ -211,7 +211,11 @@ export async function handleAnthropicMessages(
   if (fit.truncated) {
     warnPromptTruncated(fit.originalLength, fit.finalPromptLength);
   }
-  const cmdArgs = fit.args;
+  // When the prompt is delivered via stdin (or ACP), keep it OUT of argv,
+  // otherwise a long prompt still blows past the kernel ARG_MAX (spawn E2BIG
+  // on Linux). fit.args appends the full prompt for the argv path only.
+  const cmdArgs =
+    config.promptViaStdin || config.useAcp ? fixedArgs : fit.args;
 
   const msgId = `msg_${randomUUID().replace(/-/g, "")}`;
 

--- a/src/lib/handlers/chat-completions.ts
+++ b/src/lib/handlers/chat-completions.ts
@@ -177,7 +177,11 @@ export async function handleChatCompletions(
   if (fit.truncated) {
     warnPromptTruncated(fit.originalLength, fit.finalPromptLength);
   }
-  const cmdArgs = fit.args;
+  // When the prompt is delivered via stdin (or ACP), keep it OUT of argv,
+  // otherwise a long prompt still blows past the kernel ARG_MAX (spawn E2BIG
+  // on Linux). fit.args appends the full prompt for the argv path only.
+  const cmdArgs =
+    config.promptViaStdin || config.useAcp ? fixedArgs : fit.args;
 
   const id = `chatcmpl_${randomUUID().replace(/-/g, "")}`;
   const created = Math.floor(Date.now() / 1000);

--- a/src/lib/server.test.ts
+++ b/src/lib/server.test.ts
@@ -4,6 +4,7 @@ import * as fs from "node:fs";
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { startBridgeServer } from "./server.js";
 import { appendSessionLine } from "./request-log.js";
+import { run, runStreaming } from "./process.js";
 import type { BridgeConfig } from "./config.js";
 
 vi.mock("./cursor-cli.js", () => ({
@@ -337,6 +338,60 @@ describe("startBridgeServer", () => {
     const data = JSON.parse(body);
     expect(data.object).toBe("chat.completion");
     expect(data.choices[0].message.content).toBe("Hello from agent");
+  });
+
+  it("keeps the prompt out of argv and passes it via stdin when promptViaStdin is true (non-streaming)", async () => {
+    const runMock = vi.mocked(run);
+    runMock.mockClear();
+    servers = startBridgeServer({
+      version: "1.0.0",
+      config: createTestConfig({ promptViaStdin: true }),
+    });
+    await new Promise<void>((resolve) =>
+      servers[0].on("listening", () => resolve()),
+    );
+
+    const marker = "UNIQUE_PROMPT_MARKER_argv_e2big";
+    const { status } = await fetchServer(servers[0], "/v1/chat/completions", {
+      method: "POST",
+      body: JSON.stringify({
+        model: "claude-3-opus",
+        messages: [{ role: "user", content: marker }],
+      }),
+    });
+    expect(status).toBe(200);
+    expect(runMock).toHaveBeenCalledTimes(1);
+    const [, args, opts] = runMock.mock.calls[0];
+    // Prompt must NOT be in argv (would blow ARG_MAX / spawn E2BIG on long prompts).
+    expect(args.some((a: string) => a.includes(marker))).toBe(false);
+    // Prompt must be delivered via stdin instead.
+    expect(opts?.stdinContent).toContain(marker);
+  });
+
+  it("appends the prompt to argv (no stdin) when promptViaStdin is false (non-streaming)", async () => {
+    const runMock = vi.mocked(run);
+    runMock.mockClear();
+    servers = startBridgeServer({
+      version: "1.0.0",
+      config: createTestConfig({ promptViaStdin: false }),
+    });
+    await new Promise<void>((resolve) =>
+      servers[0].on("listening", () => resolve()),
+    );
+
+    const marker = "UNIQUE_PROMPT_MARKER_argv_default";
+    const { status } = await fetchServer(servers[0], "/v1/chat/completions", {
+      method: "POST",
+      body: JSON.stringify({
+        model: "claude-3-opus",
+        messages: [{ role: "user", content: marker }],
+      }),
+    });
+    expect(status).toBe(200);
+    expect(runMock).toHaveBeenCalledTimes(1);
+    const [, args, opts] = runMock.mock.calls[0];
+    expect(args.some((a: string) => a.includes(marker))).toBe(true);
+    expect(opts?.stdinContent).toBeUndefined();
   });
 
   it("returns display model when request is default and defaultModel is set", async () => {


### PR DESCRIPTION
## Problem

On Linux, requests with a long prompt fail with `spawn E2BIG`:

```
Agent stream error: Error: spawn E2BIG
  code: 'E2BIG', syscall: 'spawn'
```

The agent is spawned with the full prompt appended as an argv argument. When the
prompt is large (e.g. long conversation contexts from an agent runtime), the
argument vector exceeds the kernel `ARG_MAX` (~2 MB) and `spawn` fails before the
process starts.

Setting `CURSOR_BRIDGE_PROMPT_VIA_STDIN=true` does **not** fix this on Linux.
Both handlers do:

```ts
const cmdArgs = fit.args; // fit.args already appends the full prompt
```

`fitPromptToWinCmdline` only guards the **Windows** command-line limit; on Linux
it returns the args with the prompt appended unchanged. So even with
`promptViaStdin` enabled, the prompt was sent via **both** argv and stdin — argv
still overflowed.

This is the Linux counterpart of the Windows `ENAMETOOLONG` issue (#13), which
was only mitigated with Windows-side truncation.

## Fix

When `promptViaStdin` (or ACP) is active, build `cmdArgs` from `fixedArgs` so the
prompt is **not** placed in argv; it is delivered via stdin only.

```ts
const cmdArgs =
  config.promptViaStdin || config.useAcp ? fixedArgs : fit.args;
```

Applied to both `chat-completions.ts` and `anthropic-messages.ts`.

## Tests

Adds regression tests in `server.test.ts`:
- `promptViaStdin: true` → prompt is passed via `stdinContent`, **not** in argv.
- `promptViaStdin: false` → prompt is appended to argv, no `stdinContent`.

Full suite: 221 passing (was 219). Typecheck clean.

## Verification (real proxy, Linux)

- Direct proxy, ~5.76 MB payload: spawns successfully, **no E2BIG** (argv ends at
  `--output-format text`; prompt goes through stdin).
- Long-context request end-to-end: HTTP 200, correct response.
