### PR TITLE
feat: add requests CLI for sessions.log inspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,19 @@ npx cursor-api-proxy
 # or from repo: npm start / node dist/cli.js
 ```
 
+Inspect completed requests without opening the dashboard:
+
+```bash
+cursor-api-proxy requests
+cursor-api-proxy requests --limit 50
+cursor-api-proxy requests --watch --interval 1
+```
+
+The command reads `CURSOR_BRIDGE_SESSIONS_LOG` (default
+`~/.cursor-api-proxy/sessions.log`) directly, so the proxy does not need to be
+running. It shows completion time, method, status, remote address, and path.
+Set `NO_COLOR=1` for plain output.
+
 To expose on your network (e.g. Tailscale):
 
 ```bash

--- a/docs/WIKI.md
+++ b/docs/WIKI.md
@@ -66,9 +66,21 @@ Same idea as **claude-cursor-bridge**’s `claude-bridge`: a **bash** script in 
 | `cursor-api-proxy stop` | `SIGTERM`, then `SIGKILL` if needed |
 | `cursor-api-proxy restart` | `stop` then `start` |
 | `cursor-api-proxy health` | PID, port, launchd state, HTTP probe, last log lines |
+| `cursor-api-proxy requests` | Formatted latest completed requests from `sessions.log` |
 | `cursor-api-proxy enable` | Write `~/Library/LaunchAgents/com.cursor-api-proxy.plist` and `launchctl load` |
 | `cursor-api-proxy disable` | `launchctl unload` and remove the plist |
 | `cursor-api-proxy run` | Foreground `node …/dist/cli.js` (what launchd invokes) |
+
+Request viewer options:
+
+```bash
+cursor-api-proxy requests --limit 50
+cursor-api-proxy requests --watch --interval 1
+```
+
+The viewer reads `CURSOR_BRIDGE_SESSIONS_LOG` directly (default
+`~/.cursor-api-proxy/sessions.log`), including while the proxy is stopped.
+`NO_COLOR=1` disables ANSI colors.
 
 Environment the script honors:
 

--- a/scripts/cursor-api-proxy
+++ b/scripts/cursor-api-proxy
@@ -310,6 +310,12 @@ cmd_health() {
   _health_text
 }
 
+cmd_requests() {
+  local node exe
+  _load_entry || exit 1
+  exec "$node" "$exe" requests "$@"
+}
+
 cmd_menu() {
   while true; do
     echo
@@ -344,8 +350,9 @@ main() {
     rebuild) cmd_rebuild ;;
     folder) cmd_folder ;;
     run) cmd_run ;;
+    requests) shift; cmd_requests "$@" ;;
     "" ) cmd_health; echo; cmd_menu ;;
-    *) echo "Usage: $0 {start|stop|restart|health|enable|disable|rebuild|folder|run}" >&2; exit 2 ;;
+    *) echo "Usage: $0 {start|stop|restart|health|enable|disable|rebuild|folder|run|requests}" >&2; exit 2 ;;
   esac
 }
 

--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -18,6 +18,10 @@ describe("parseArgs", () => {
     deepClean: false,
     dryRun: false,
     verbose: false,
+    requests: false,
+    requestLimit: 20,
+    watch: false,
+    watchIntervalMs: 2000,
     mode: undefined as undefined,
   };
 
@@ -213,5 +217,48 @@ describe("parseArgs", () => {
 
   it("throws when --mode has no value", () => {
     expect(() => parseArgs(["--mode"])).toThrow(/requires a value/);
+  });
+
+  it("parses requests with default options", () => {
+    expect(parseArgs(["requests"])).toEqual({
+      ...base,
+      requests: true,
+      tailscale: false,
+      help: false,
+      login: false,
+      logout: false,
+      accountsList: false,
+      accountName: "",
+      proxies: [],
+    });
+  });
+
+  it("parses requests watch options", () => {
+    expect(
+      parseArgs(["requests", "--limit", "50", "--watch", "--interval=0.5"]),
+    ).toEqual({
+      ...base,
+      requests: true,
+      requestLimit: 50,
+      watch: true,
+      watchIntervalMs: 500,
+      tailscale: false,
+      help: false,
+      login: false,
+      logout: false,
+      accountsList: false,
+      accountName: "",
+      proxies: [],
+    });
+  });
+
+  it("rejects invalid request options", () => {
+    expect(() => parseArgs(["requests", "--limit", "0"])).toThrow(
+      /between 1 and 5000/,
+    );
+    expect(() => parseArgs(["requests", "--interval", "nope"])).toThrow(
+      /positive number/,
+    );
+    expect(() => parseArgs(["--watch"])).toThrow(/require requests command/);
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,10 +5,12 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import { loadBridgeConfig } from "./lib/config.js";
+import { loadEnvConfig } from "./lib/env.js";
 import { startBridgeServer, setupGracefulShutdown } from "./lib/server.js";
 import { parseArgs, printHelp } from "./cli/args.js";
 import { handleAccountsList, handleLogout } from "./cli/accounts.js";
 import { handleLogin } from "./cli/login.js";
+import { handleRequests } from "./cli/requests.js";
 import { handleResetHwid } from "./cli/reset-hwid.js";
 
 // Re-export parseArgs so src/cli.test.ts can import it without a separate path
@@ -34,6 +36,17 @@ async function main(): Promise<void> {
 
   if (args.help) {
     printHelp(pkg.version);
+    return;
+  }
+
+  if (args.requests) {
+    const env = loadEnvConfig({ env: process.env });
+    await handleRequests({
+      logPath: env.sessionsLogPath,
+      limit: args.requestLimit,
+      watch: args.watch,
+      intervalMs: args.watchIntervalMs,
+    });
     return;
   }
 

--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -5,6 +5,10 @@ export type ParsedArgs = {
   tailscale: boolean;
   verbose: boolean;
   help: boolean;
+  requests: boolean;
+  requestLimit: number;
+  watch: boolean;
+  watchIntervalMs: number;
   login: boolean;
   accountsList: boolean;
   logout: boolean;
@@ -21,6 +25,11 @@ export function parseArgs(argv: string[]): ParsedArgs {
   let tailscale = false;
   let verbose = false;
   let help = false;
+  let requests = false;
+  let requestLimit = 20;
+  let watch = false;
+  let watchIntervalMs = 2000;
+  let requestOptionUsed = false;
   let login = false;
   let accountsList = false;
   let logout = false;
@@ -33,6 +42,53 @@ export function parseArgs(argv: string[]): ParsedArgs {
 
   for (let i = 0; i < argv.length; i++) {
     const arg = argv[i];
+
+    if (arg === "requests") {
+      requests = true;
+      continue;
+    }
+
+    if (arg === "--limit" || arg.startsWith("--limit=")) {
+      const value = arg === "--limit" ? argv[++i] : arg.slice("--limit=".length);
+      if (!value || value.startsWith("-")) {
+        throw new Error("--limit requires a positive integer");
+      }
+      requestLimit = Number(value);
+      if (
+        !Number.isInteger(requestLimit) ||
+        requestLimit < 1 ||
+        requestLimit > 5000
+      ) {
+        throw new Error("--limit must be an integer between 1 and 5000");
+      }
+      requestOptionUsed = true;
+      continue;
+    }
+
+    if (arg === "--watch") {
+      watch = true;
+      requestOptionUsed = true;
+      continue;
+    }
+
+    if (arg === "--interval" || arg.startsWith("--interval=")) {
+      const value =
+        arg === "--interval" ? argv[++i] : arg.slice("--interval=".length);
+      if (!value || value.startsWith("-")) {
+        throw new Error(
+          "--interval requires a positive number between 0.001 and 86400 seconds",
+        );
+      }
+      const seconds = Number(value);
+      if (!Number.isFinite(seconds) || seconds < 0.001 || seconds > 86_400) {
+        throw new Error(
+          "--interval requires a positive number between 0.001 and 86400 seconds",
+        );
+      }
+      watchIntervalMs = Math.round(seconds * 1000);
+      requestOptionUsed = true;
+      continue;
+    }
 
     if (arg === "login" || arg === "add-account") {
       login = true;
@@ -113,10 +169,18 @@ export function parseArgs(argv: string[]): ParsedArgs {
     throw new Error(`Unknown argument: ${arg}`);
   }
 
+  if (requestOptionUsed && !requests) {
+    throw new Error("--limit, --watch, and --interval require requests command");
+  }
+
   return {
     tailscale,
     verbose,
     help,
+    requests,
+    requestLimit,
+    watch,
+    watchIntervalMs,
     login,
     accountsList,
     logout,
@@ -150,6 +214,12 @@ export function printHelp(version: string): void {
   console.log(
     "  reset-hwid --deep-clean   Also wipe session storage and cookies",
   );
+  console.log(
+    "  requests                  Show latest completed API requests",
+  );
+  console.log(
+    "  requests --watch          Refresh latest requests continuously",
+  );
   console.log("");
   console.log("Options:");
   console.log("  --tailscale     Bind to 0.0.0.0 for tailnet/LAN access");
@@ -157,5 +227,8 @@ export function printHelp(version: string): void {
   console.log(
     "  --mode <agent|ask|plan>  Default Cursor CLI mode (overridden by env or per-request)",
   );
+  console.log("  --limit <n>     Requests to show (1-5000, default 20)");
+  console.log("  --watch         Refresh requests continuously");
+  console.log("  --interval <s>  Watch refresh interval (default 2)");
   console.log("  -h, --help      Show this help message");
 }

--- a/src/cli/requests.test.ts
+++ b/src/cli/requests.test.ts
@@ -1,0 +1,143 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  formatRequests,
+  handleRequests,
+  readRecentRequests,
+} from "./requests.js";
+import type { SessionRequest } from "../lib/session-log.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+const requests: SessionRequest[] = [
+  {
+    ts: "2026-07-13T12:00:00.000Z",
+    method: "POST",
+    pathname: "/v1/chat/completions/with/a/very/long/path",
+    remoteAddress: "127.0.0.1",
+    status: 200,
+  },
+  {
+    ts: "2026-07-13T12:00:01.000Z",
+    method: "POST",
+    pathname: "/v1/messages",
+    remoteAddress: "::1",
+    status: 429,
+  },
+  {
+    ts: "2026-07-13T12:00:02.000Z",
+    method: "GET",
+    pathname: "/health",
+    remoteAddress: "::1",
+    status: 500,
+  },
+];
+
+describe("requests command", () => {
+  it("renders a plain, width-aware table", () => {
+    const rendered = formatRequests(requests, {
+      logPath: "/tmp/sessions.log",
+      width: 60,
+      color: false,
+    });
+
+    expect(rendered).toContain("WHEN");
+    expect(rendered).toContain("FROM");
+    expect(rendered).toContain("127.0.0.1");
+    expect(rendered).toContain("/v1/chat/completions/wit…");
+    for (const line of rendered.split("\n")) {
+      expect(line.length).toBeLessThanOrEqual(60);
+    }
+  });
+
+  it("colors status classes and includes remote addresses on wide terminals", () => {
+    const rendered = formatRequests(requests, {
+      logPath: "/tmp/sessions.log",
+      width: 100,
+      color: true,
+    });
+
+    expect(rendered).toContain("FROM");
+    expect(rendered).toContain("127.0.0.1");
+    expect(rendered).toContain("\x1b[32m200");
+    expect(rendered).toContain("\x1b[33m429");
+    expect(rendered).toContain("\x1b[31m500");
+  });
+
+  it("reads newest normal request lines and skips error records", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "requests-cli-"));
+    tempDirs.push(dir);
+    const logPath = path.join(dir, "sessions.log");
+    fs.writeFileSync(
+      logPath,
+      [
+        "2026-07-13T12:00:00.000Z GET /first ::1 200",
+        "2026-07-13T12:00:01.000Z ERROR GET /first ::1 agent_exit_1 failed",
+        "2026-07-13T12:00:02.000Z POST /second ::1 500",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const result = await readRecentRequests(logPath, 1);
+    expect(result).toHaveLength(1);
+    expect(result[0].pathname).toBe("/second");
+  });
+
+  it("prints an empty state for a missing log", async () => {
+    let output = "";
+    await handleRequests({
+      logPath: "/path/that/does/not/exist/sessions.log",
+      limit: 20,
+      watch: false,
+      intervalMs: 2000,
+      output: {
+        isTTY: false,
+        columns: 80,
+        write(chunk) {
+          output += chunk;
+        },
+      },
+      env: {},
+    });
+
+    expect(output).toContain("Latest requests (0)");
+    expect(output).toContain("No requests found.");
+    expect(output).not.toContain("\x1b[");
+  });
+
+  it("refreshes in watch mode until aborted", async () => {
+    let output = "";
+    const controller = new AbortController();
+    const running = handleRequests({
+      logPath: "/path/that/does/not/exist/sessions.log",
+      limit: 20,
+      watch: true,
+      intervalMs: 5,
+      signal: controller.signal,
+      output: {
+        isTTY: false,
+        columns: 80,
+        write(chunk) {
+          output += chunk;
+        },
+      },
+      env: {},
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    controller.abort();
+    await running;
+
+    expect(output.match(/Latest requests \(0\)/g)?.length).toBeGreaterThan(1);
+  });
+});

--- a/src/cli/requests.ts
+++ b/src/cli/requests.ts
@@ -1,0 +1,203 @@
+import {
+  readLastLines,
+  recentSessionRequests,
+  type SessionRequest,
+} from "../lib/session-log.js";
+
+const ANSI = {
+  reset: "\x1b[0m",
+  bold: "\x1b[1m",
+  cyan: "\x1b[36m",
+  green: "\x1b[32m",
+  yellow: "\x1b[33m",
+  red: "\x1b[31m",
+  dim: "\x1b[2m",
+};
+
+export type RequestsOutput = {
+  write(chunk: string): unknown;
+  columns?: number;
+  isTTY?: boolean;
+};
+
+export type FormatRequestsOptions = {
+  logPath: string;
+  width?: number;
+  color?: boolean;
+};
+
+export type HandleRequestsOptions = {
+  logPath: string;
+  limit: number;
+  watch: boolean;
+  intervalMs: number;
+  output?: RequestsOutput;
+  env?: NodeJS.ProcessEnv;
+  signal?: AbortSignal;
+};
+
+function truncate(value: string, width: number): string {
+  if (value.length <= width) return value;
+  if (width <= 1) return value.slice(0, width);
+  return `${value.slice(0, width - 1)}…`;
+}
+
+function pad(value: string, width: number): string {
+  return truncate(value, width).padEnd(width);
+}
+
+function localTimestamp(value: string): string {
+  const date = new Date(value);
+  const two = (n: number) => String(n).padStart(2, "0");
+  return [
+    date.getFullYear(),
+    "-",
+    two(date.getMonth() + 1),
+    "-",
+    two(date.getDate()),
+    " ",
+    two(date.getHours()),
+    ":",
+    two(date.getMinutes()),
+    ":",
+    two(date.getSeconds()),
+  ].join("");
+}
+
+function paint(value: string, code: string, enabled: boolean): string {
+  return enabled ? `${code}${value}${ANSI.reset}` : value;
+}
+
+function statusColor(status: number): string {
+  if (status >= 500) return ANSI.red;
+  if (status >= 400) return ANSI.yellow;
+  return ANSI.green;
+}
+
+export function formatRequests(
+  requests: SessionRequest[],
+  opts: FormatRequestsOptions,
+): string {
+  const width = Math.max(50, opts.width ?? 100);
+  const color = opts.color ?? false;
+  const compact = width < 80;
+  const whenWidth = compact ? 8 : 19;
+  const methodWidth = compact ? 6 : 7;
+  const statusWidth = compact ? 3 : 6;
+  const remoteWidth = compact ? 10 : 20;
+  const separators = 8;
+  const fixedWidth =
+    whenWidth + methodWidth + statusWidth + remoteWidth + separators;
+  const pathWidth = Math.max(12, width - fixedWidth);
+  const title = truncate(
+    `Latest requests (${requests.length}) · ${opts.logPath}`,
+    width,
+  );
+
+  if (requests.length === 0) {
+    return [
+      paint(title, ANSI.bold, color),
+      paint("No requests found.", ANSI.dim, color),
+    ].join("\n");
+  }
+
+  const columns = [
+    pad("WHEN", whenWidth),
+    pad("METHOD", methodWidth),
+    pad("STATUS", statusWidth),
+    pad("FROM", remoteWidth),
+    pad("PATH", pathWidth),
+  ];
+  const lines = [
+    paint(title, ANSI.bold, color),
+    paint(columns.join("  "), ANSI.dim, color),
+    paint("─".repeat(width), ANSI.dim, color),
+  ];
+
+  for (const request of requests) {
+    const timestamp = localTimestamp(request.ts);
+    const method = pad(request.method, methodWidth);
+    const status = pad(String(request.status), statusWidth);
+    const row = [
+      pad(compact ? timestamp.slice(11) : timestamp, whenWidth),
+      paint(method, ANSI.cyan, color),
+      paint(status, statusColor(request.status), color),
+      pad(request.remoteAddress, remoteWidth),
+      pad(request.pathname, pathWidth),
+    ];
+    lines.push(row.join("  "));
+  }
+
+  return lines.join("\n");
+}
+
+export function readRecentRequests(
+  logPath: string,
+  limit: number,
+): Promise<SessionRequest[]> {
+  const linesToRead = Math.min(20_000, Math.max(100, limit * 4));
+  return new Promise((resolve, reject) => {
+    readLastLines(logPath, linesToRead, (err, lines) => {
+      if (err) reject(err);
+      else resolve(recentSessionRequests(lines, limit));
+    });
+  });
+}
+
+export async function handleRequests(
+  opts: HandleRequestsOptions,
+): Promise<void> {
+  const output = opts.output ?? process.stdout;
+  const env = opts.env ?? process.env;
+  const color = Boolean(output.isTTY) && env.NO_COLOR === undefined;
+  const render = async (redraw: boolean): Promise<void> => {
+    const requests = await readRecentRequests(opts.logPath, opts.limit);
+    const formatted = formatRequests(requests, {
+      logPath: opts.logPath,
+      width: output.columns,
+      color,
+    });
+    if (redraw && output.isTTY) output.write("\x1b[2J\x1b[H");
+    output.write(`${formatted}\n`);
+  };
+
+  await render(false);
+  if (!opts.watch) return;
+
+  await new Promise<void>((resolve, reject) => {
+    let rendering = false;
+    let stopped = false;
+    const removeStopListener = () => {
+      if (opts.signal) opts.signal.removeEventListener("abort", stop);
+      else process.off("SIGINT", stop);
+    };
+    const stop = () => {
+      if (stopped) return;
+      stopped = true;
+      clearInterval(timer);
+      removeStopListener();
+      if (output.isTTY) output.write("\n");
+      resolve();
+    };
+    const timer = setInterval(() => {
+      if (rendering || stopped) return;
+      rendering = true;
+      render(true)
+        .catch((err) => {
+          clearInterval(timer);
+          removeStopListener();
+          reject(err);
+        })
+        .finally(() => {
+          rendering = false;
+        });
+    }, opts.intervalMs);
+
+    if (opts.signal) {
+      if (opts.signal.aborted) stop();
+      else opts.signal.addEventListener("abort", stop, { once: true });
+    } else {
+      process.once("SIGINT", stop);
+    }
+  });
+}

--- a/src/lib/admin-dashboard.ts
+++ b/src/lib/admin-dashboard.ts
@@ -5,6 +5,7 @@ import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import type { BridgeConfig } from "./config.js";
+import { computeSessionStats, readLastLines } from "./session-log.js";
 
 const PLIST_LABEL = "com.cursor-api-proxy";
 
@@ -67,70 +68,6 @@ function launchdLoadedSync(): boolean {
   } catch {
     return false;
   }
-}
-
-function readLastLines(
-  filePath: string,
-  maxLines: number,
-  cb: (err: Error | null, lines: string[]) => void,
-): void {
-  fs.stat(filePath, (err, stat) => {
-    if (err) return cb(null, []);
-    const size = stat.size;
-    const CHUNK = 64 * 1024;
-    const start = Math.max(0, size - CHUNK * 4);
-    const stream = fs.createReadStream(filePath, { start, end: size });
-    let buf = "";
-    stream.on("data", (d) => (buf += d.toString("utf8")));
-    stream.on("end", () => {
-      const lines = buf.split("\n");
-      if (start > 0 && lines.length) lines.shift();
-      const trimmed = lines.filter((l) => l.length > 0);
-      cb(null, trimmed.slice(-maxLines));
-    });
-    stream.on("error", (e) => cb(e, []));
-  });
-}
-
-const SESSION_LINE_RE =
-  /^(\S+) (GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS) (\S+) (\S+) (\d{3})$/;
-
-type SessionStats = {
-  windowHours: number;
-  total: number;
-  errors: number;
-  byPath: Record<string, number>;
-  recent: { ts: string; method: string; pathname: string; status: number }[];
-};
-
-function computeStats(lines: string[], hours: number): SessionStats {
-  const cutoff = Date.now() - hours * 3600_000;
-  const stats: SessionStats = {
-    windowHours: hours,
-    total: 0,
-    errors: 0,
-    byPath: {},
-    recent: [],
-  };
-  for (const line of lines) {
-    const m = line.match(SESSION_LINE_RE);
-    if (!m) continue;
-    const ts = Date.parse(m[1]);
-    if (!Number.isFinite(ts) || ts < cutoff) continue;
-    const status = Number(m[5]);
-    const pathname = m[3];
-    stats.total++;
-    if (status >= 400) stats.errors++;
-    stats.byPath[pathname] = (stats.byPath[pathname] ?? 0) + 1;
-    stats.recent.push({
-      ts: m[1],
-      method: m[2],
-      pathname,
-      status,
-    });
-  }
-  stats.recent = stats.recent.slice(-40).reverse();
-  return stats;
 }
 
 function storagePaths(config: BridgeConfig) {
@@ -374,7 +311,7 @@ export function handleAdminDashboard(
     const hours = Math.min(168, Math.max(1, Number(q.hours) || 24));
     return readLastLines(config.sessionsLogPath, 20_000, (err, lines) => {
       if (err) return json(res, 500, { error: String(err) });
-      json(res, 200, computeStats(lines, hours));
+      json(res, 200, computeSessionStats(lines, hours));
     });
   }
   if (req.method === "GET" && pathname === "/api/wiki") {

--- a/src/lib/session-log.test.ts
+++ b/src/lib/session-log.test.ts
@@ -1,0 +1,108 @@
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  computeSessionStats,
+  parseSessionLine,
+  readLastLines,
+  recentSessionRequests,
+} from "./session-log.js";
+
+const tempDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of tempDirs.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function readLines(filePath: string, maxLines: number): Promise<string[]> {
+  return new Promise((resolve, reject) => {
+    readLastLines(filePath, maxLines, (err, lines) => {
+      if (err) reject(err);
+      else resolve(lines);
+    });
+  });
+}
+
+describe("session log", () => {
+  it("parses normal request lines including IPv6 addresses", () => {
+    expect(
+      parseSessionLine(
+        "2026-07-13T12:00:00.000Z POST /v1/chat/completions ::1 200",
+      ),
+    ).toEqual({
+      ts: "2026-07-13T12:00:00.000Z",
+      method: "POST",
+      pathname: "/v1/chat/completions",
+      remoteAddress: "::1",
+      status: 200,
+    });
+  });
+
+  it("ignores error and malformed lines", () => {
+    expect(
+      parseSessionLine(
+        "2026-07-13T12:00:00.000Z ERROR POST /v1/messages ::1 agent_exit_1 failed",
+      ),
+    ).toBeNull();
+    expect(parseSessionLine("not a request")).toBeNull();
+  });
+
+  it("returns newest requests first and applies the limit", () => {
+    const lines = [
+      "2026-07-13T12:00:00.000Z GET /first 127.0.0.1 200",
+      "2026-07-13T12:00:01.000Z ERROR GET /first 127.0.0.1 failed",
+      "2026-07-13T12:00:02.000Z POST /second ::1 500",
+    ];
+
+    expect(recentSessionRequests(lines, 1)).toEqual([
+      {
+        ts: "2026-07-13T12:00:02.000Z",
+        method: "POST",
+        pathname: "/second",
+        remoteAddress: "::1",
+        status: 500,
+      },
+    ]);
+  });
+
+  it("computes dashboard-compatible stats", () => {
+    const recent = new Date(Date.now() - 60_000).toISOString();
+    const old = new Date(Date.now() - 48 * 3600_000).toISOString();
+    const stats = computeSessionStats(
+      [
+        `${old} GET /old ::1 200`,
+        `${recent} GET /health ::1 200`,
+        `${recent} POST /v1/messages ::1 429`,
+      ],
+      24,
+    );
+
+    expect(stats).toEqual({
+      windowHours: 24,
+      total: 2,
+      errors: 1,
+      byPath: { "/health": 1, "/v1/messages": 1 },
+      recent: [
+        { ts: recent, method: "POST", pathname: "/v1/messages", status: 429 },
+        { ts: recent, method: "GET", pathname: "/health", status: 200 },
+      ],
+    });
+  });
+
+  it("tails files and treats a missing file as empty", async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), "session-log-"));
+    tempDirs.push(dir);
+    const logPath = path.join(dir, "sessions.log");
+    fs.writeFileSync(logPath, "one\ntwo\nthree\n", "utf8");
+
+    await expect(readLines(logPath, 2)).resolves.toEqual(["two", "three"]);
+    await expect(readLines(path.join(dir, "missing.log"), 2)).resolves.toEqual(
+      [],
+    );
+  });
+});

--- a/src/lib/session-log.ts
+++ b/src/lib/session-log.ts
@@ -1,0 +1,105 @@
+import * as fs from "node:fs";
+
+const SESSION_LINE_RE =
+  /^(\S+) (GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS) (\S+) (\S+) (\d{3})$/;
+
+export type SessionRequest = {
+  ts: string;
+  method: string;
+  pathname: string;
+  remoteAddress: string;
+  status: number;
+};
+
+export type SessionStats = {
+  windowHours: number;
+  total: number;
+  errors: number;
+  byPath: Record<string, number>;
+  recent: Omit<SessionRequest, "remoteAddress">[];
+};
+
+export function readLastLines(
+  filePath: string,
+  maxLines: number,
+  cb: (err: Error | null, lines: string[]) => void,
+): void {
+  fs.stat(filePath, (err, stat) => {
+    if (err) return cb(null, []);
+    const size = stat.size;
+    const chunk = 64 * 1024;
+    const start = Math.max(0, size - chunk * 4);
+    const stream = fs.createReadStream(filePath, { start, end: size });
+    let buf = "";
+    stream.on("data", (data) => (buf += data.toString("utf8")));
+    stream.on("end", () => {
+      const lines = buf.split("\n");
+      if (start > 0 && lines.length) lines.shift();
+      const trimmed = lines.filter((line) => line.length > 0);
+      cb(null, trimmed.slice(-maxLines));
+    });
+    stream.on("error", (streamErr) => cb(streamErr, []));
+  });
+}
+
+export function parseSessionLine(line: string): SessionRequest | null {
+  const match = line.match(SESSION_LINE_RE);
+  if (!match) return null;
+
+  const ts = Date.parse(match[1]);
+  const status = Number(match[5]);
+  if (!Number.isFinite(ts) || !Number.isInteger(status)) return null;
+
+  return {
+    ts: match[1],
+    method: match[2],
+    pathname: match[3],
+    remoteAddress: match[4],
+    status,
+  };
+}
+
+export function recentSessionRequests(
+  lines: string[],
+  limit: number,
+): SessionRequest[] {
+  const requests: SessionRequest[] = [];
+  for (let i = lines.length - 1; i >= 0 && requests.length < limit; i--) {
+    const request = parseSessionLine(lines[i]);
+    if (request) requests.push(request);
+  }
+  return requests;
+}
+
+export function computeSessionStats(
+  lines: string[],
+  hours: number,
+): SessionStats {
+  const cutoff = Date.now() - hours * 3600_000;
+  const stats: SessionStats = {
+    windowHours: hours,
+    total: 0,
+    errors: 0,
+    byPath: {},
+    recent: [],
+  };
+
+  for (const line of lines) {
+    const request = parseSessionLine(line);
+    if (!request || Date.parse(request.ts) < cutoff) continue;
+
+    stats.total++;
+    if (request.status >= 400) stats.errors++;
+    stats.byPath[request.pathname] =
+      (stats.byPath[request.pathname] ?? 0) + 1;
+    stats.recent.push({
+      ts: request.ts,
+      method: request.method,
+      pathname: request.pathname,
+      status: request.status,
+    });
+  }
+
+  stats.recent = stats.recent.slice(-40).reverse();
+  return stats;
+}


### PR DESCRIPTION
## Summary
- Extract shared `session-log` parsing/tailing from the admin dashboard
- Add `cursor-api-proxy requests` with `--limit`, `--watch`, and `--interval`
- Wire the wrapper script and document the command

## Test plan
- [ ] `npm test` / `npm run typecheck`
- [ ] `node dist/cli.js requests` shows recent lines from `~/.cursor-api-proxy/sessions.log`
- [ ] `node dist/cli.js requests --limit 5 --watch --interval 1` refreshes until Ctrl-C
- [ ] `scripts/cursor-api-proxy requests --limit 10` works via wrapper
- [ ] Dashboard `/api/status` still returns session stats after the extract


Made with [Cursor](https://cursor.com)