### PR TITLE
fix: cancel agent work on client disconnect

### DIFF
--- a/src/lib/client-disconnect.test.ts
+++ b/src/lib/client-disconnect.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+
+import { abortOnClientDisconnect } from "./client-disconnect.js";
+
+describe("abortOnClientDisconnect", () => {
+  it("aborts when the response closes without writableEnded", () => {
+    const res = createFakeResponse();
+    const controller = new AbortController();
+    abortOnClientDisconnect(res as never, controller);
+    expect(controller.signal.aborted).toBe(false);
+    res.emit("close");
+    expect(controller.signal.aborted).toBe(true);
+  });
+
+  it("does not abort on a normal finished response close", () => {
+    const res = createFakeResponse();
+    const controller = new AbortController();
+    abortOnClientDisconnect(res as never, controller);
+    res.writableEnded = true;
+    res.emit("close");
+    expect(controller.signal.aborted).toBe(false);
+  });
+
+  it("aborts immediately when the response is already destroyed", () => {
+    const res = createFakeResponse({ destroyed: true });
+    const controller = new AbortController();
+    abortOnClientDisconnect(res as never, controller);
+    expect(controller.signal.aborted).toBe(true);
+  });
+});
+
+function createFakeResponse(opts: { destroyed?: boolean } = {}) {
+  const listeners = new Map<string, Array<() => void>>();
+  const res = {
+    writableEnded: false,
+    destroyed: !!opts.destroyed,
+    once(event: string, cb: () => void) {
+      const list = listeners.get(event) ?? [];
+      list.push(cb);
+      listeners.set(event, list);
+      return res;
+    },
+    emit(event: string) {
+      for (const cb of listeners.get(event) ?? []) cb();
+    },
+  };
+  return res;
+}

--- a/src/lib/client-disconnect.ts
+++ b/src/lib/client-disconnect.ts
@@ -1,0 +1,22 @@
+import type * as http from "node:http";
+
+/**
+ * Cancels in-flight agent work when the caller goes away.
+ *
+ * This has to hang off the *response*, not the request: `req` emits "close" as
+ * soon as its body has been received, which always happens before a handler
+ * runs, so a listener added there can never observe a disconnect. `res` tracks
+ * the socket, but it also closes on a normal finish — hence the guard.
+ */
+export function abortOnClientDisconnect(
+  res: http.ServerResponse,
+  controller: AbortController,
+): void {
+  if (res.writableEnded || res.destroyed) {
+    controller.abort();
+    return;
+  }
+  res.once("close", () => {
+    if (!res.writableEnded) controller.abort();
+  });
+}

--- a/src/lib/handlers/anthropic-messages.ts
+++ b/src/lib/handlers/anthropic-messages.ts
@@ -44,6 +44,7 @@ import {
   fitPromptToWinCmdline,
   warnPromptTruncated,
 } from "../win-cmdline-limit.js";
+import { abortOnClientDisconnect } from "../client-disconnect.js";
 
 function isRateLimited(stderr: string): boolean {
   return /\b429\b|rate.?limit|too many requests/i.test(stderr);
@@ -258,7 +259,7 @@ export async function handleAnthropicMessages(
     const streamStart = Date.now();
 
     const abortController = new AbortController();
-    req.once("close", () => abortController.abort());
+    abortOnClientDisconnect(res, abortController);
 
     if (config.useAcp && typeof promptForAgent === "string") {
       let accumulated = "";
@@ -430,7 +431,7 @@ export async function handleAnthropicMessages(
   const syncStart = Date.now();
 
   const abortController = new AbortController();
-  req.once("close", () => abortController.abort());
+  abortOnClientDisconnect(res, abortController);
 
   const out = await runAgentSync(
     config,

--- a/src/lib/handlers/chat-completions.ts
+++ b/src/lib/handlers/chat-completions.ts
@@ -39,6 +39,7 @@ import {
   reportRequestError,
   getAccountStats,
 } from "../account-pool.js";
+import { abortOnClientDisconnect } from "../client-disconnect.js";
 import {
   fitPromptToWinCmdline,
   warnPromptTruncated,
@@ -200,7 +201,7 @@ export async function handleChatCompletions(
     const streamStart = Date.now();
 
     const abortController = new AbortController();
-    req.once("close", () => abortController.abort());
+    abortOnClientDisconnect(res, abortController);
 
     writeSseHeaders(res, truncatedHeaders);
     res.on("error", () => {
@@ -421,7 +422,7 @@ export async function handleChatCompletions(
   const syncStart = Date.now();
 
   const abortController = new AbortController();
-  req.once("close", () => abortController.abort());
+  abortOnClientDisconnect(res, abortController);
 
   const out = await runAgentSync(
     config,

--- a/src/lib/handlers/responses.ts
+++ b/src/lib/handlers/responses.ts
@@ -45,6 +45,7 @@ import {
   fitPromptToWinCmdline,
   warnPromptTruncated,
 } from "../win-cmdline-limit.js";
+import { abortOnClientDisconnect } from "../client-disconnect.js";
 import { getCachedCursorModels, type ModelCacheRef } from "./models.js";
 
 function isRateLimited(stderr: string): boolean {
@@ -304,7 +305,7 @@ export async function handleResponses(
     const streamStart = Date.now();
 
     const abortController = new AbortController();
-    req.once("close", () => abortController.abort());
+    abortOnClientDisconnect(res, abortController);
 
     writeSseHeaders(res, truncatedHeaders);
     res.on("error", () => {
@@ -525,7 +526,7 @@ export async function handleResponses(
   const syncStart = Date.now();
 
   const abortController = new AbortController();
-  req.once("close", () => abortController.abort());
+  abortOnClientDisconnect(res, abortController);
 
   const out = await runAgentSync(
     config,

--- a/src/lib/server-client-disconnect.test.ts
+++ b/src/lib/server-client-disconnect.test.ts
@@ -1,0 +1,133 @@
+import * as http from "node:http";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { BridgeConfig } from "./config.js";
+import { run } from "./process.js";
+import { startBridgeServer } from "./server.js";
+
+vi.mock("./cursor-cli.js", () => ({
+  listCursorCliModels: vi
+    .fn()
+    .mockResolvedValue([{ id: "claude-3-opus", name: "Claude 3 Opus" }]),
+}));
+
+vi.mock("./process.js", () => ({
+  killAllChildProcesses: vi.fn(),
+  run: vi.fn(),
+  runStreaming: vi.fn(),
+}));
+
+vi.mock("./request-log.js", () => ({
+  logIncoming: vi.fn(),
+  logTrafficRequest: vi.fn(),
+  logTrafficResponse: vi.fn(),
+  logModelResolution: vi.fn(),
+  logAgentError: vi.fn().mockReturnValue("agent error"),
+  appendSessionLine: vi.fn(),
+  logAccountAssigned: vi.fn(),
+  logAccountStats: vi.fn(),
+}));
+
+function createTestConfig(
+  overrides: Partial<BridgeConfig> = {},
+): BridgeConfig {
+  return {
+    agentBin: "agent",
+    acpCommand: "agent",
+    acpArgs: ["acp"],
+    acpEnv: {},
+    host: "127.0.0.1",
+    port: 0,
+    defaultModel: "default",
+    mode: "ask",
+    force: false,
+    approveMcps: false,
+    strictModel: true,
+    workspace: process.cwd(),
+    timeoutMs: 30_000,
+    sessionsLogPath: "/tmp/cursor-proxy-disconnect-test.log",
+    chatOnlyWorkspace: true,
+    chatOnlyWorkspaceExplicit: false,
+    verbose: false,
+    maxMode: false,
+    promptViaStdin: false,
+    useAcp: false,
+    acpSkipAuthenticate: false,
+    acpRawDebug: false,
+    configDirs: [],
+    multiPort: false,
+    winCmdlineMax: 30_000,
+    contextPreamble: true,
+    bridgePackageVersion: "0.0.0-test",
+    ...overrides,
+  };
+}
+
+/** Sends a request, then destroys the socket once the agent has been reached. */
+function requestThenDisconnect(
+  server: http.Server,
+  body: string,
+): Promise<void> {
+  const port = (server.address() as { port: number }).port;
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      `http://127.0.0.1:${port}/v1/chat/completions`,
+      { method: "POST", headers: { "content-type": "application/json" } },
+      () => {
+        /* no response expected — we bail out first */
+      },
+    );
+    req.on("error", () => resolve());
+    req.write(body);
+    req.end();
+    setTimeout(() => {
+      req.destroy();
+      resolve();
+    }, 150).unref?.();
+    setTimeout(() => reject(new Error("disconnect timeout")), 5_000).unref?.();
+  });
+}
+
+describe("client disconnect", () => {
+  let servers: http.Server[] = [];
+
+  afterEach(async () => {
+    for (const s of servers) await new Promise((r) => s.close(r));
+    servers = [];
+    vi.mocked(run).mockReset();
+  });
+
+  it("aborts the agent when the client goes away mid-request", async () => {
+    let seenSignal: AbortSignal | undefined;
+    const agentReached = new Promise<void>((resolve) => {
+      vi.mocked(run).mockImplementation((_bin, _args, opts) => {
+        seenSignal = opts?.signal;
+        resolve();
+        return new Promise(() => {});
+      });
+    });
+
+    servers = startBridgeServer({
+      version: "1.0.0",
+      config: createTestConfig(),
+    }) as http.Server[];
+    await new Promise<void>((r) => servers[0].on("listening", () => r()));
+
+    const disconnected = requestThenDisconnect(
+      servers[0],
+      JSON.stringify({
+        model: "claude-3-opus",
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    );
+
+    await agentReached;
+    expect(seenSignal).toBeDefined();
+    expect(seenSignal!.aborted).toBe(false);
+
+    await disconnected;
+    await vi.waitFor(() => {
+      expect(seenSignal!.aborted).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Track disconnect on the **response** socket (`res.close`), not `req.close` (body-complete is too early).
- Abort in-flight agent work for chat completions, Responses, and Anthropic handlers.

## Test plan
- [x] `npm test -- src/lib/client-disconnect.test.ts src/lib/server-client-disconnect.test.ts src/lib/server.test.ts`
- [ ] Manual: start a long request, kill the client; confirm agent child exits


Made with [Cursor](https://cursor.com)