### PR TITLE
fix: reap agent process trees on exit

### DIFF
--- a/src/lib/acp-client.ts
+++ b/src/lib/acp-client.ts
@@ -9,6 +9,7 @@ import { spawn } from "node:child_process";
 import { debuglog } from "node:util";
 
 import { trackChildProcess } from "./process.js";
+import { DETACH_CHILDREN, killProcessTree } from "./process-tree-kill.js";
 
 const debugAcp = debuglog("cursor-api-proxy:acp");
 
@@ -281,6 +282,7 @@ export function runAcpSync(
       env: buildAcpSpawnEnv(opts.env),
       stdio: ["pipe", "pipe", "pipe"],
       windowsVerbatimArguments: opts.spawnOptions?.windowsVerbatimArguments,
+      detached: DETACH_CHILDREN,
     });
 
     trackChildProcess(child);
@@ -290,11 +292,7 @@ export function runAcpSync(
     let resolved = false;
 
     const onAbort = () => {
-      try {
-        child.kill("SIGTERM");
-      } catch {
-        /* ignore */
-      }
+      killProcessTree(child, "SIGTERM");
     };
     if (opts.signal) {
       if (opts.signal.aborted) onAbort();
@@ -313,10 +311,10 @@ export function runAcpSync(
       }
       try {
         child.stdin?.end();
-        child.kill("SIGKILL");
       } catch {
         /* ignore */
       }
+      killProcessTree(child, "SIGKILL");
       resolve({
         code,
         stdout: accumulated.trim(),
@@ -493,6 +491,7 @@ export function runAcpStream(
       env: buildAcpSpawnEnv(opts.env),
       stdio: ["pipe", "pipe", "pipe"],
       windowsVerbatimArguments: opts.spawnOptions?.windowsVerbatimArguments,
+      detached: DETACH_CHILDREN,
     });
 
     trackChildProcess(child);
@@ -501,11 +500,7 @@ export function runAcpStream(
     let resolved = false;
 
     const onAbort = () => {
-      try {
-        child.kill("SIGTERM");
-      } catch {
-        /* ignore */
-      }
+      killProcessTree(child, "SIGTERM");
     };
     if (opts.signal) {
       if (opts.signal.aborted) onAbort();
@@ -524,10 +519,10 @@ export function runAcpStream(
       }
       try {
         child.stdin?.end();
-        child.kill("SIGKILL");
       } catch {
         /* ignore */
       }
+      killProcessTree(child, "SIGKILL");
       resolve({ code, stderr: stderr.trim() });
     };
 

--- a/src/lib/process-tree-kill.test.ts
+++ b/src/lib/process-tree-kill.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi, afterEach } from "vitest";
+
+import { killProcessTree } from "./process-tree-kill.js";
+
+type FakeChild = {
+  pid?: number;
+  kill: (signal?: NodeJS.Signals) => boolean;
+};
+
+function fakeChild(pid: number | undefined): FakeChild {
+  return { pid, kill: vi.fn(() => true) };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("killProcessTree", () => {
+  it("signals the whole process group so grandchildren die with the agent", () => {
+    const groupKill = vi.spyOn(process, "kill").mockReturnValue(true);
+    const child = fakeChild(4321);
+
+    killProcessTree(child as never, "SIGTERM", { detached: true });
+
+    expect(groupKill).toHaveBeenCalledWith(-4321, "SIGTERM");
+    expect(child.kill).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the direct child when the group is already gone", () => {
+    vi.spyOn(process, "kill").mockImplementation(() => {
+      throw Object.assign(new Error("no such process"), { code: "ESRCH" });
+    });
+    const child = fakeChild(4321);
+
+    killProcessTree(child as never, "SIGKILL", { detached: true });
+
+    expect(child.kill).toHaveBeenCalledWith("SIGKILL");
+  });
+
+  it("signals only the child when the process was not detached", () => {
+    const groupKill = vi.spyOn(process, "kill").mockReturnValue(true);
+    const child = fakeChild(4321);
+
+    killProcessTree(child as never, "SIGTERM", { detached: false });
+
+    expect(groupKill).not.toHaveBeenCalled();
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+  });
+
+  it("signals only the child when no pid is available", () => {
+    const groupKill = vi.spyOn(process, "kill").mockReturnValue(true);
+    const child = fakeChild(undefined);
+
+    killProcessTree(child as never, "SIGTERM", { detached: true });
+
+    expect(groupKill).not.toHaveBeenCalled();
+    expect(child.kill).toHaveBeenCalledWith("SIGTERM");
+  });
+
+  it("never throws when the child has already exited", () => {
+    vi.spyOn(process, "kill").mockImplementation(() => {
+      throw new Error("boom");
+    });
+    const child = fakeChild(4321);
+    child.kill = vi.fn(() => {
+      throw new Error("already exited");
+    });
+
+    expect(() =>
+      killProcessTree(child as never, "SIGTERM", { detached: true }),
+    ).not.toThrow();
+  });
+});

--- a/src/lib/process-tree-kill.ts
+++ b/src/lib/process-tree-kill.ts
@@ -1,0 +1,31 @@
+import type { ChildProcess } from "node:child_process";
+
+/**
+ * The Cursor CLI spawns its own helpers (a TypeScript language server among
+ * them) that outlive the agent process. Signalling only the agent leaves those
+ * grandchildren running inside the service cgroup, where they accumulate until
+ * the memory limit is hit. Agents are therefore spawned as process-group
+ * leaders and signalled by negative pid so the whole group goes down together.
+ */
+export const DETACH_CHILDREN = process.platform !== "win32";
+
+export function killProcessTree(
+  child: ChildProcess,
+  signal: NodeJS.Signals,
+  opts: { detached?: boolean } = {},
+): void {
+  const detached = opts.detached ?? DETACH_CHILDREN;
+  if (detached && typeof child.pid === "number") {
+    try {
+      process.kill(-child.pid, signal);
+      return;
+    } catch {
+      /* group already gone — fall through to the direct child */
+    }
+  }
+  try {
+    child.kill(signal);
+  } catch {
+    /* already exited */
+  }
+}

--- a/src/lib/process.ts
+++ b/src/lib/process.ts
@@ -1,5 +1,6 @@
 import { spawn, type ChildProcess } from "node:child_process";
 import { resolveAgentCommand } from "./env.js";
+import { DETACH_CHILDREN, killProcessTree } from "./process-tree-kill.js";
 import { runMaxModePreflight } from "./max-mode-preflight.js";
 
 export type RunResult = {
@@ -36,11 +37,7 @@ const activeChildren = new Set<ChildProcess>();
 /** Kill all in-flight agent child processes. Called on server shutdown. */
 export function killAllChildProcesses(): void {
   for (const child of activeChildren) {
-    try {
-      child.kill("SIGTERM");
-    } catch {
-      /* already exited */
-    }
+    killProcessTree(child, "SIGTERM");
   }
   activeChildren.clear();
 }
@@ -90,6 +87,7 @@ function spawnChild(
     env,
     stdio: useStdin ? ["pipe", "pipe", "pipe"] : ["ignore", "pipe", "pipe"],
     windowsVerbatimArguments: resolved.windowsVerbatimArguments,
+    detached: DETACH_CHILDREN,
   });
 
   if (useStdin && opts!.stdinContent !== undefined && child.stdin) {
@@ -124,15 +122,15 @@ export function runStreaming(
     const timeout =
       typeof timeoutMs === "number" && timeoutMs > 0
         ? setTimeout(() => {
-            child.kill("SIGKILL");
+            killProcessTree(child, "SIGKILL");
           }, timeoutMs)
         : undefined;
 
     // Abort signal support — kill child when client disconnects
-    const onAbort = () => child.kill("SIGTERM");
+    const onAbort = () => killProcessTree(child, "SIGTERM");
     if (opts.signal) {
       if (opts.signal.aborted) {
-        child.kill("SIGTERM");
+        killProcessTree(child, "SIGTERM");
       } else {
         opts.signal.addEventListener("abort", onAbort, { once: true });
       }
@@ -173,6 +171,7 @@ export function runStreaming(
       if (timeout) clearTimeout(timeout);
       opts.signal?.removeEventListener("abort", onAbort);
       activeChildren.delete(child);
+      killProcessTree(child, "SIGKILL");
       if (lineBuffer.trim()) opts.onLine(lineBuffer.trim());
       if (signal) {
         const signalNote = `terminated by signal ${signal}`;
@@ -203,14 +202,14 @@ export function run(
     const timeout =
       typeof timeoutMs === "number" && timeoutMs > 0
         ? setTimeout(() => {
-            child.kill("SIGKILL");
+            killProcessTree(child, "SIGKILL");
           }, timeoutMs)
         : undefined;
 
-    const onAbort = () => child.kill("SIGTERM");
+    const onAbort = () => killProcessTree(child, "SIGTERM");
     if (opts.signal) {
       if (opts.signal.aborted) {
-        child.kill("SIGTERM");
+        killProcessTree(child, "SIGTERM");
       } else {
         opts.signal.addEventListener("abort", onAbort, { once: true });
       }
@@ -243,6 +242,7 @@ export function run(
       if (timeout) clearTimeout(timeout);
       opts.signal?.removeEventListener("abort", onAbort);
       activeChildren.delete(child);
+      killProcessTree(child, "SIGKILL");
       if (signal) {
         const signalNote = `terminated by signal ${signal}`;
         stderr = stderr.trim() ? `${stderr.trim()}\n${signalNote}` : signalNote;


### PR DESCRIPTION
## Summary
- Spawn CLI/ACP agents as process-group leaders on non-Windows (`detached`).
- Kill by negative PID so grandchildren (e.g. language-server helpers) do not linger after timeout, disconnect, or shutdown.

## Test plan
- [x] `npm test -- src/lib/process-tree-kill.test.ts src/lib/process.test.ts src/lib/acp-client.test.ts`
- [ ] Manual: start agent request, abort/timeout; confirm no leftover helper processes


Made with [Cursor](https://cursor.com)