### PR TITLE
feat: ACP tool passthrough for issue 36

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This package works as **one npm dependency**: use it as an **SDK** in your app t
 ## Prerequisites (required for the proxy to work)
 
 - **Node.js** 18+
-- **Cursor agent CLI** (`agent`). This package does **not** install or bundle the CLI. You must install and set it up separately. This project is developed and tested with `agent` version **2026.02.27-e7d2ef6**.
+- **Cursor agent CLI** (`cursor-agent` or `agent`). This package does **not** install or bundle the CLI. You must install and set it up separately. The proxy prefers `cursor-agent` on `PATH`, then falls back to `agent`; set `CURSOR_AGENT_BIN` when another vendor also installs an `agent` command.
 
   ```bash
   curl https://cursor.com/install -fsS | bash
@@ -111,6 +111,56 @@ When you point an agent runtime (OpenClaw, LangChain, a custom harness, etc.) at
 - **Server-side workspace (optional):** The Cursor CLI may run with a workspace directory (`CURSOR_BRIDGE_WORKSPACE`, per-request `X-Cursor-Workspace`). By default, `CURSOR_BRIDGE_CHAT_ONLY_WORKSPACE=true` runs the CLI in an **empty temp directory** so it does not read or write your real project; the proxy also overrides `HOME`, `USERPROFILE`, and `CURSOR_CONFIG_DIR` so the agent does not load global or project rules from elsewhere. Set it to `false` if you intentionally want the CLI to see a path on the machine where the proxy runs (still not the same as IDE indexing—see env table below).
 - **Recommended patterns for agents:** Use **client-side tools** (e.g. `read_file`, `run_terminal_cmd`) and pass results as tool messages; add **RAG** or retrieval and inject snippets into `user` content; or paste relevant files into the prompt. There is no built-in “sync entire workspace through the proxy” today; if that changes, it will be documented here.
 
+### Client tool passthrough (ACP)
+
+Set `CURSOR_BRIDGE_USE_ACP=true` to receive structured client tool calls. Tool-bearing requests require a Cursor ACP build that advertises HTTP MCP support. The proxy supports:
+
+- Chat Completions `tools` / legacy `functions` → `message.tool_calls`; resume with `role: "tool"` and `tool_call_id`.
+- Responses flat function tools → `function_call` output items; resume with `previous_response_id` and `function_call_output`.
+- Anthropic tools with `input_schema` → `tool_use`; resume with `tool_result`.
+- Sync and streaming output, mixed text plus tools, parallel calls, multiple rounds, named/required/none choices.
+
+The proxy exposes each request's schemas through a random, bearer-authenticated MCP URL bound only to `127.0.0.1`. It never executes caller tools. It parks Cursor's MCP call, returns the native API tool call to your framework, then delivers your framework's result back to the same live ACP turn. Proxy-owned MCP permission is allowed once; built-in and ambient tool permissions remain rejected.
+
+Tool loops are intentionally stateful and in-process:
+
+- Keep the same proxy process alive between the call and its result.
+- Submit results before `CURSOR_BRIDGE_TIMEOUT_MS`; expiration, restart, unknown IDs, or wrong API-key owner return HTTP `409`.
+- Parallel results may arrive together or incrementally. The original account/profile and temporary workspace stay attached until the turn finishes.
+- A client disconnect while a turn is active cancels the ACP child and removes temporary state.
+- Responses API objects remain externally `completed` while an internal ACP turn waits for `function_call_output`.
+
+Minimal Chat Completions loop:
+
+```js
+const messages = [{ role: "user", content: "Weather in Paris?" }];
+const tools = [{
+  type: "function",
+  function: {
+    name: "weather",
+    parameters: {
+      type: "object",
+      properties: { city: { type: "string" } },
+      required: ["city"],
+    },
+  },
+}];
+
+const first = await client.chat.completions.create({
+  model: "auto",
+  messages,
+  tools,
+});
+const assistant = first.choices[0].message;
+messages.push(assistant);
+for (const call of assistant.tool_calls ?? []) {
+  const args = JSON.parse(call.function.arguments);
+  const output = await getWeather(args.city); // executed by your app
+  messages.push({ role: "tool", tool_call_id: call.id, content: output });
+}
+const final = await client.chat.completions.create({ model: "auto", messages });
+```
+
 ## Use as SDK in another project
 
 Install the package and ensure the **Cursor agent CLI is installed and set up** (see Prerequisites). When you use the SDK with the default URL, **the proxy starts in the background automatically** if it is not already running. You can still start it yourself with `npx cursor-api-proxy` or set `CURSOR_PROXY_URL` to point at an existing proxy (then the SDK will not start another).
@@ -177,9 +227,9 @@ const client = new OpenAI({
 | ------ | ---------------------- | --------------------------------------------------------------------- |
 | GET    | `/health`              | Server and config info                                                |
 | GET    | `/v1/models`           | List Cursor models (from `agent --list-models`)                       |
-| POST   | `/v1/chat/completions` | Chat completion (OpenAI shape; supports `stream: true`)               |
-| POST   | `/v1/responses`        | Responses API text generation shape; supports semantic SSE streaming  |
-| POST   | `/v1/messages`         | Anthropic Messages API (used by Claude Code; supports `stream: true`) |
+| POST   | `/v1/chat/completions` | Chat + native `tool_calls`; supports `stream: true`                    |
+| POST   | `/v1/responses`        | Responses text + `function_call`; supports semantic SSE streaming     |
+| POST   | `/v1/messages`         | Anthropic Messages + `tool_use`; supports `stream: true`              |
 
 **Usage / token fields:** Responses may include `usage` token fields (`prompt_tokens`/`completion_tokens` for Chat Completions, `input_tokens`/`output_tokens` for Responses). These are **heuristic estimates** (character count ÷ 4), not Cursor billing meters. Do not use them for invoicing.
 
@@ -196,10 +246,10 @@ Environment handling is centralized in one module. Aliases, defaults, path resol
 | `CURSOR_BRIDGE_WORKSPACE` | process cwd | Base workspace directory for Cursor CLI. With `CURSOR_BRIDGE_CHAT_ONLY_WORKSPACE=false`, header `X-Cursor-Workspace` must point to an **existing directory under this path** (after resolving real paths). |
 | `CURSOR_BRIDGE_MODE` | — | Server default for Cursor CLI `--mode`: **`agent`**, **`ask`**, or **`plan`**. If unset, default is **`ask`**. **Env wins over** CLI `--mode` when both are set. Per request, JSON body **`mode`** or header **`X-Cursor-Mode`** overrides (precedence: body → header → this env → `--mode` → `ask`). Invalid value → startup error. With **`agent`** (or **`plan`**) and real workspace, the CLI may **read/write files** under `CURSOR_BRIDGE_WORKSPACE` / cwd—see `CURSOR_BRIDGE_CHAT_ONLY_WORKSPACE`. |
 | `CURSOR_BRIDGE_DEFAULT_MODEL` | `auto` | Default model when request omits one |
-| `CURSOR_BRIDGE_STRICT_MODEL` | `true` | Use last requested model when none specified |
+| `CURSOR_BRIDGE_STRICT_MODEL` | `true` | Reject a requested model when Cursor's CLI/ACP catalogs cannot match it instead of silently selecting the ACP session default. |
 | `CURSOR_BRIDGE_FORCE` | `false` | Pass `--force` to Cursor CLI |
 | `CURSOR_BRIDGE_APPROVE_MCPS` | `false` | Pass `--approve-mcps` to Cursor CLI |
-| `CURSOR_BRIDGE_TIMEOUT_MS` | `300000` | Timeout per completion (ms) |
+| `CURSOR_BRIDGE_TIMEOUT_MS` | `300000` | Timeout per completion and idle TTL for a parked client-tool turn (ms). |
 | `CURSOR_BRIDGE_TLS_CERT` | — | Path to TLS certificate file (e.g. Tailscale cert). Use with `CURSOR_BRIDGE_TLS_KEY` for HTTPS. |
 | `CURSOR_BRIDGE_TLS_KEY` | — | Path to TLS private key file. Use with `CURSOR_BRIDGE_TLS_CERT` for HTTPS. |
 | `CURSOR_BRIDGE_SESSIONS_LOG` | `~/.cursor-api-proxy/sessions.log` | Path to log file; each request is appended as a line (timestamp, method, path, IP, status). |
@@ -212,10 +262,10 @@ Environment handling is centralized in one module. Aliases, defaults, path resol
 | `CURSOR_CONFIG_DIRS` | — | Comma-separated configuration directories for round-robin account rotation (alias: `CURSOR_ACCOUNT_DIRS`). Auto-discovers authenticated accounts under `~/.cursor-api-proxy/accounts/` when unset. |
 | `CURSOR_BRIDGE_MULTI_PORT` | `false` | When `true` and multiple config dirs are set, spawns a separate server per directory on incrementing ports starting from `CURSOR_BRIDGE_PORT`. |
 | `CURSOR_BRIDGE_PROMPT_VIA_STDIN` | `false` | When `true`, sends the user prompt via **stdin** instead of argv (helps on Windows if argv is truncated). |
-| `CURSOR_BRIDGE_USE_ACP` | `false` | When `true`, uses **ACP (Agent Client Protocol)** over stdio (`agent acp`). Avoids Windows argv limits. See [Cursor ACP docs](https://cursor.com/docs/cli/acp). Set `NODE_DEBUG=cursor-api-proxy:acp` to debug. |
+| `CURSOR_BRIDGE_USE_ACP` | `false` | When `true`, uses **ACP (Agent Client Protocol)** over stdio (`agent acp`). Required for structured client-tool passthrough and avoids Windows argv limits. The installed agent must advertise HTTP MCP support. See [Cursor ACP docs](https://cursor.com/docs/cli/acp). Set `NODE_DEBUG=cursor-api-proxy:acp` to debug. |
 | `CURSOR_BRIDGE_ACP_SKIP_AUTHENTICATE` | auto | When `CURSOR_API_KEY` is set, skips the ACP authenticate step. Set to `true` to skip when using `agent login` instead. |
 | `CURSOR_BRIDGE_ACP_RAW_DEBUG` | `false` | When `1` or `true`, log raw JSON-RPC from ACP stdout (requires `NODE_DEBUG=cursor-api-proxy:acp`). |
-| `CURSOR_AGENT_BIN` | `agent` | Path to Cursor CLI binary. Alias precedence: `CURSOR_AGENT_BIN`, then `CURSOR_CLI_BIN`, then `CURSOR_CLI_PATH`. |
+| `CURSOR_AGENT_BIN` | auto | Path to Cursor CLI binary. Explicit alias precedence: `CURSOR_AGENT_BIN`, then `CURSOR_CLI_BIN`, then `CURSOR_CLI_PATH`; otherwise prefer executable `cursor-agent` on `PATH`, then executable `agent`. |
 | `CURSOR_AGENT_NODE` | — | **(Windows)** Path to Node.js. With `CURSOR_AGENT_SCRIPT`, spawns Node directly and bypasses cmd.exe’s ~8191 limit (CreateProcess ~32K still applies; see `CURSOR_BRIDGE_WIN_CMDLINE_MAX`). |
 | `CURSOR_AGENT_SCRIPT` | — | **(Windows)** Path to the agent script (e.g. `agent.cmd` or `.js`). Use with `CURSOR_AGENT_NODE` for long prompts. |
 
@@ -223,7 +273,7 @@ Notes:
 
 - The `login` subcommand depends on `chrome-launcher`; its dependency tree may pull typings into production installs. Prefer `npm audit` before release; upstream may move types to `devDependencies` over time.
 - `--tailscale` changes the default host to `0.0.0.0` only when `CURSOR_BRIDGE_HOST` is not already set.
-- ACP `session/request_permission` uses `reject-once` (least-privilege) so the agent cannot grant file/tool access; intentional for chat-only mode.
+- ACP `session/request_permission` uses `allow-once` only for the per-turn proxy-owned client-tool MCP invocation. Built-in and ambient tools use `reject-once`.
 - Relative paths such as `CURSOR_BRIDGE_WORKSPACE`, `CURSOR_BRIDGE_SESSIONS_LOG`, `CURSOR_BRIDGE_TLS_CERT`, and `CURSOR_BRIDGE_TLS_KEY` are resolved from the current working directory.
 
 #### Windows command line limits

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "cursor-api-proxy",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cursor-api-proxy",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "MIT",
       "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.30.0",
         "chrome-launcher": "^1.2.1"
       },
       "bin": {
@@ -465,12 +466,64 @@
         "node": ">=18"
       }
     },
+    "node_modules/@hono/node-server": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.1.1.tgz",
+      "integrity": "sha512-ELuehkj5VCBdgEw9zs+ivkKwyzzUCSQuE96YmiPvn1ECBoZCczbFXJLeEGMTYjphP6gydh4pHMqEYPVMYUVgQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.5.5",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
       "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+      "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
+      "license": "MIT",
+      "dependencies": {
+        "@hono/node-server": "^1.19.9 || ^2.0.5",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.59.0",
@@ -974,6 +1027,52 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/assertion-error": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
@@ -982,6 +1081,81 @@
       "license": "MIT",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/chai": {
@@ -1012,6 +1186,77 @@
         "node": ">=12.13.0"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1029,12 +1274,80 @@
         }
       }
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
       "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -1078,6 +1391,12 @@
         "@esbuild/win32-x64": "0.27.3"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
     "node_modules/escape-string-regexp": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
@@ -1100,6 +1419,36 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.1.tgz",
+      "integrity": "sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/expect-type": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
@@ -1109,6 +1458,90 @@
       "engines": {
         "node": ">=12.0.0"
       }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+      "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -1128,6 +1561,45 @@
         }
       }
     },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -1141,6 +1613,157 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.13.3",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.3.tgz",
+      "integrity": "sha512-r8AO2mYHoLxSHkgafNeC/BXyb2vWRxD3jem4Ts+ptav8oTG5FIRifAjuJEmZI4bSvvc2ns0GxmIYiZnHqN3mMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ip-address": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.5.0.tgz",
+      "integrity": "sha512-R5SnVLJmgYYvf2F2ZgwSBnelz5G4q5AxIC277GDfUaNbrZKNANcBC7RHqYYePlszf4kBolVkJauG0ZjHHFh55g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
       }
     },
     "node_modules/is-docker": {
@@ -1158,6 +1781,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT"
+    },
     "node_modules/is-wsl": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
@@ -1169,6 +1798,33 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
+    "node_modules/jose": {
+      "version": "6.2.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.9.tgz",
+      "integrity": "sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause"
     },
     "node_modules/lighthouse-logger": {
       "version": "2.0.2",
@@ -1196,6 +1852,65 @@
       "integrity": "sha512-ocnPZQLNpvbedwTy9kNrQEsknEfgvcLMvOtz3sFeWApDq1MXH1TqkCIx58xlpESsfwQOnuBO9beyQuNGzVvuhQ==",
       "license": "Apache-2.0"
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -1221,6 +1936,36 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/obug": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
@@ -1231,6 +1976,55 @@
         "https://opencollective.com/debug"
       ],
       "license": "MIT"
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -1257,6 +2051,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/postcss": {
@@ -1286,6 +2089,72 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/rollup": {
@@ -1333,6 +2202,172 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT"
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/siginfo": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
@@ -1356,6 +2391,15 @@
       "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/std-env": {
       "version": "3.10.0",
@@ -1408,6 +2452,46 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.1.0.tgz",
+      "integrity": "sha512-mj7UPXE0jaqaOsukNZRUEfEi2AcL7C/vwmwcHV0O97eO1E1pxBZuyjlZrx5seTaNBg1U6+o35wpa35Qfcc+7ag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -1427,6 +2511,24 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/vite": {
       "version": "7.3.1",
@@ -1581,6 +2683,21 @@
         }
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/why-is-node-running": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
@@ -1596,6 +2713,30 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cursor-api-proxy",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "OpenAI-compatible proxy for Cursor CLI — use Cursor models from any LLM client on localhost",
   "private": false,
   "type": "module",
@@ -51,6 +51,7 @@
     "vitest": "^4.0.18"
   },
   "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.30.0",
     "chrome-launcher": "^1.2.1"
   }
 }

--- a/src/client.ts
+++ b/src/client.ts
@@ -25,6 +25,75 @@ export type CursorProxyClientOptions = {
   startProxy?: boolean;
 };
 
+export type CursorProxyFunctionTool = {
+  type: "function";
+  function: {
+    name: string;
+    description?: string;
+    parameters?: Record<string, unknown>;
+  };
+};
+
+export type CursorProxyToolCall = {
+  id: string;
+  type: "function";
+  function: { name: string; arguments: string };
+};
+
+export type CursorProxyChatMessage = {
+  role: string;
+  content?: unknown;
+  tool_calls?: CursorProxyToolCall[];
+  tool_call_id?: string;
+  name?: string;
+};
+
+export type CursorProxyChatCompletionsParams = {
+  model?: string;
+  messages: CursorProxyChatMessage[];
+  stream?: false;
+  tools?: CursorProxyFunctionTool[];
+  tool_choice?: unknown;
+  functions?: Array<{
+    name: string;
+    description?: string;
+    parameters?: Record<string, unknown>;
+  }>;
+  function_call?: unknown;
+  parallel_tool_calls?: boolean;
+};
+
+export type CursorProxyResponsesParams = {
+  model?: string;
+  input: unknown;
+  stream?: false;
+  tools?: Array<{
+    type: "function";
+    name: string;
+    description?: string;
+    parameters?: Record<string, unknown>;
+  }>;
+  tool_choice?: unknown;
+  parallel_tool_calls?: boolean;
+  previous_response_id?: string;
+  store?: boolean;
+  [key: string]: unknown;
+};
+
+export type CursorProxyAnthropicMessagesParams = {
+  model?: string;
+  max_tokens: number;
+  messages: Array<{ role: "user" | "assistant"; content: unknown }>;
+  stream?: false;
+  tools?: Array<{
+    name: string;
+    description?: string;
+    input_schema: Record<string, unknown>;
+  }>;
+  tool_choice?: unknown;
+  [key: string]: unknown;
+};
+
 let _proxyProcess: import("node:child_process").ChildProcess | null = null;
 let _managedProxyStartupPromise: Promise<string> | null = null;
 let _managedProxyStartedBySdk = false;
@@ -365,19 +434,62 @@ export function createCursorProxyClient(options: CursorProxyClientOptions = {}) 
     },
 
     /** OpenAI-style chat completions (non-streaming). */
-    async chatCompletionsCreate(params: {
-      model?: string;
-      messages: Array<{ role: string; content: string }>;
-      stream?: false;
-    }) {
+    async chatCompletionsCreate(params: CursorProxyChatCompletionsParams) {
       const { data, ok, status } = await this.request<{
-        choices?: Array<{ message?: { content?: string } }>;
+        choices?: Array<{
+          message?: {
+            content?: string | null;
+            tool_calls?: CursorProxyToolCall[];
+          };
+          finish_reason?: "stop" | "tool_calls" | string;
+        }>;
         error?: { message?: string };
       }>("/v1/chat/completions", {
+        ...params,
         model: params.model ?? "default",
-        messages: params.messages,
         stream: false,
       });
+      if (!ok) {
+        const err = data?.error?.message ?? JSON.stringify(data);
+        throw new Error(`cursor-api-proxy error (${status}): ${err}`);
+      }
+      return data;
+    },
+
+    /** OpenAI Responses API (non-streaming), including function_call output. */
+    async responsesCreate(params: CursorProxyResponsesParams) {
+      const { data, ok, status } = await this.request<{
+        id?: string;
+        output_text?: string;
+        output?: Array<{
+          type?: string;
+          call_id?: string;
+          name?: string;
+          arguments?: string;
+        }>;
+        error?: { message?: string };
+      }>("/v1/responses", { ...params, stream: false });
+      if (!ok) {
+        const err = data?.error?.message ?? JSON.stringify(data);
+        throw new Error(`cursor-api-proxy error (${status}): ${err}`);
+      }
+      return data;
+    },
+
+    /** Anthropic Messages API (non-streaming), including tool_use blocks. */
+    async anthropicMessagesCreate(params: CursorProxyAnthropicMessagesParams) {
+      const { data, ok, status } = await this.request<{
+        id?: string;
+        content?: Array<{
+          type?: string;
+          text?: string;
+          id?: string;
+          name?: string;
+          input?: unknown;
+        }>;
+        stop_reason?: string;
+        error?: { message?: string };
+      }>("/v1/messages", { ...params, stream: false });
       if (!ok) {
         const err = data?.error?.message ?? JSON.stringify(data);
         throw new Error(`cursor-api-proxy error (${status}): ${err}`);

--- a/src/lib/__tests__/fake-acp-server.mjs
+++ b/src/lib/__tests__/fake-acp-server.mjs
@@ -1,15 +1,18 @@
 /**
- * Minimal fake ACP server for integration tests.
- * Reads JSON-RPC from stdin, responds to initialize, authenticate, session/new, session/prompt.
- *
- * Env:
- * - FAKE_ACP_SCENARIO: unset | empty_models | dup_names | fail_set_config
- *
- * Emits to stderr for assertions: __FAKE_ACP_SET_CONFIG__:<json>\n
+ * Fake ACP server. Tool scenarios act as an MCP HTTP client so tests exercise
+ * the real proxy-owned MCP transport and parked tools/call lifecycle.
  */
 import { createInterface } from "node:readline";
 
 const scenario = process.env.FAKE_ACP_SCENARIO || "";
+const waiting = new Map();
+let mcpServers = [];
+let nextMcpId = 1;
+let nextClientRequestId = 10_000;
+
+function send(message) {
+  process.stdout.write(`${JSON.stringify({ jsonrpc: "2.0", ...message })}\n`);
+}
 
 function sessionNewResult() {
   if (scenario === "empty_models") {
@@ -26,6 +29,19 @@ function sessionNewResult() {
       },
     };
   }
+  if (scenario === "display_model") {
+    return {
+      sessionId: "sess-1",
+      models: {
+        availableModels: [
+          {
+            modelId: "gpt-5.6-sol[reasoning=high]",
+            name: "GPT-5.6 Sol High",
+          },
+        ],
+      },
+    };
+  }
   return {
     sessionId: "sess-1",
     models: {
@@ -34,63 +50,283 @@ function sessionNewResult() {
   };
 }
 
+function update(sessionUpdate, value = {}) {
+  send({
+    method: "session/update",
+    params: { update: { sessionUpdate, ...value } },
+  });
+}
+
+function askClient(method, params) {
+  const id = nextClientRequestId++;
+  return new Promise((resolve, reject) => {
+    waiting.set(id, { resolve, reject });
+    send({ id, method, params });
+  });
+}
+
+function mcpHeaders(server, sessionId) {
+  const headers = {
+    accept: "application/json, text/event-stream",
+    "content-type": "application/json",
+    "mcp-protocol-version": "2025-03-26",
+  };
+  for (const header of server.headers ?? []) {
+    headers[header.name] = header.value;
+  }
+  if (sessionId) headers["mcp-session-id"] = sessionId;
+  return headers;
+}
+
+async function mcpPost(server, method, params, sessionId) {
+  const id = nextMcpId++;
+  const response = await fetch(server.url, {
+    method: "POST",
+    headers: mcpHeaders(server, sessionId),
+    body: JSON.stringify({ jsonrpc: "2.0", id, method, params }),
+  });
+  const text = await response.text();
+  if (!response.ok) {
+    throw new Error(`MCP ${method} failed ${response.status}: ${text}`);
+  }
+  const parsed = JSON.parse(text);
+  if (parsed.error) throw new Error(parsed.error.message);
+  return {
+    result: parsed.result,
+    sessionId: response.headers.get("mcp-session-id") ?? sessionId,
+  };
+}
+
+async function mcpNotify(server, method, params, sessionId) {
+  const response = await fetch(server.url, {
+    method: "POST",
+    headers: mcpHeaders(server, sessionId),
+    body: JSON.stringify({ jsonrpc: "2.0", method, params }),
+  });
+  if (!response.ok) {
+    throw new Error(`MCP ${method} notification failed ${response.status}`);
+  }
+}
+
+async function connectMcp() {
+  const server = mcpServers[0];
+  if (!server?.url) throw new Error("session/new did not receive HTTP MCP");
+  const initialized = await mcpPost(
+    server,
+    "initialize",
+    {
+      protocolVersion: "2025-03-26",
+      capabilities: {},
+      clientInfo: { name: "fake-acp", version: "1" },
+    },
+    undefined,
+  );
+  await mcpNotify(
+    server,
+    "notifications/initialized",
+    {},
+    initialized.sessionId,
+  );
+  return { server, sessionId: initialized.sessionId };
+}
+
+async function requestToolPermission(name, index) {
+  const toolCallId = `fake-tool-${index}`;
+  update("tool_call", {
+    toolCallId,
+    title: "MCP: tool",
+    kind: "other",
+    status: "pending",
+  });
+  const response = await askClient("session/request_permission", {
+    sessionId: "sess-1",
+    toolCall: {
+      toolCallId,
+      title: "MCP: tool",
+      kind: "other",
+    },
+    options: [
+      { optionId: "allow-once", name: "Allow once", kind: "allow_once" },
+      {
+        optionId: "reject-once",
+        name: "Reject once",
+        kind: "reject_once",
+      },
+    ],
+  });
+  process.stderr.write(
+    `__FAKE_ACP_PERMISSION__:${JSON.stringify(response)}\n`,
+  );
+  if (response?.outcome?.optionId !== "allow-once") {
+    throw new Error("Proxy rejected caller MCP tool");
+  }
+}
+
+async function callTool(server, sessionId, tool, index) {
+  await requestToolPermission(tool.name, index);
+  const response = await mcpPost(
+    server,
+    "tools/call",
+    {
+      name: tool.name,
+      arguments: { city: index === 0 ? "Paris" : "London", index },
+    },
+    sessionId,
+  );
+  return response.result?.content?.[0]?.text ?? "";
+}
+
+async function runToolPrompt() {
+  const { server, sessionId } = await connectMcp();
+  const listed = await mcpPost(server, "tools/list", {}, sessionId);
+  const tools = listed.result?.tools ?? [];
+  if (tools.length === 0) throw new Error("MCP returned no tools");
+  if (scenario === "tool_delay") {
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  update("agent_message_chunk", { content: { text: "Checking tools. " } });
+  const parallel = scenario === "tool_parallel";
+  const count = parallel ? Math.min(2, tools.length) : 1;
+  const outputs = parallel
+    ? await Promise.all(
+        Array.from({ length: count }, (_, index) =>
+          callTool(server, sessionId, tools[index], index),
+        ),
+      )
+    : [await callTool(server, sessionId, tools[0], 0)];
+  if (scenario === "tool_two_round") {
+    outputs.push(await callTool(server, sessionId, tools[0], 1));
+  }
+  update("agent_message_chunk", {
+    content: { text: `Tool result: ${outputs.join(", ")}` },
+  });
+}
+
+async function runBuiltinPermissionPrompt() {
+  const response = await askClient("session/request_permission", {
+    sessionId: "sess-1",
+    toolCall: {
+      toolCallId: "builtin-1",
+      title: "Run shell command",
+      kind: "execute",
+    },
+    options: [
+      { optionId: "allow-once", name: "Allow once", kind: "allow_once" },
+      {
+        optionId: "reject-once",
+        name: "Reject once",
+        kind: "reject_once",
+      },
+    ],
+  });
+  process.stderr.write(
+    `__FAKE_ACP_PERMISSION__:${JSON.stringify(response)}\n`,
+  );
+  update("agent_message_chunk", { content: { text: "Builtin handled" } });
+}
+
+function isToolScenario() {
+  return scenario.startsWith("tool_");
+}
+
 const rl = createInterface({ input: process.stdin });
 rl.on("line", (line) => {
+  let msg;
   try {
-    const msg = JSON.parse(line);
-    if (msg.id != null && msg.method) {
-      if (msg.method === "session/set_config_option") {
-        process.stderr.write(`__FAKE_ACP_SET_CONFIG__:${JSON.stringify(msg.params)}\n`);
-      }
-
-      if (msg.method === "session/set_config_option" && scenario === "fail_set_config") {
-        process.stdout.write(
-          JSON.stringify({
-            jsonrpc: "2.0",
-            id: msg.id,
-            error: { code: -32603, message: "Internal error" },
-          }) + "\n",
-        );
-        return;
-      }
-
-      let result = {};
-      if (msg.method === "initialize") result = { protocolVersion: 1 };
-      else if (msg.method === "authenticate") result = {};
-      else if (msg.method === "session/new") result = sessionNewResult();
-      else if (msg.method === "session/set_config_option") result = {};
-      else if (msg.method === "session/prompt") {
-        result = {};
-        if (scenario === "with_thought") {
-          process.stdout.write(
-            JSON.stringify({
-              jsonrpc: "2.0",
-              method: "session/update",
-              params: {
-                update: {
-                  sessionUpdate: "agent_thought_chunk",
-                  content: { text: "SECRET_THOUGHT" },
-                },
-              },
-            }) + "\n",
-          );
-        }
-        process.stdout.write(
-          JSON.stringify({
-            jsonrpc: "2.0",
-            method: "session/update",
-            params: {
-              update: {
-                sessionUpdate: "agent_message_chunk",
-                content: { text: "Hello from fake ACP" },
-              },
-            },
-          }) + "\n",
-        );
-      }
-      process.stdout.write(JSON.stringify({ jsonrpc: "2.0", id: msg.id, result }) + "\n");
-    }
+    msg = JSON.parse(line);
   } catch {
-    /* ignore */
+    return;
   }
+
+  if (msg.id != null && !msg.method) {
+    const waiter = waiting.get(msg.id);
+    if (waiter) {
+      waiting.delete(msg.id);
+      if (msg.error) waiter.reject(new Error(msg.error.message));
+      else waiter.resolve(msg.result);
+    }
+    return;
+  }
+  if (msg.id == null || !msg.method) return;
+
+  if (msg.method === "session/set_config_option") {
+    process.stderr.write(
+      `__FAKE_ACP_SET_CONFIG__:${JSON.stringify(msg.params)}\n`,
+    );
+  }
+  if (
+    msg.method === "session/set_config_option" &&
+    scenario === "fail_set_config"
+  ) {
+    send({
+      id: msg.id,
+      error: { code: -32603, message: "Internal error" },
+    });
+    return;
+  }
+
+  if (msg.method === "initialize") {
+    send({
+      id: msg.id,
+      result: {
+        protocolVersion: 1,
+        agentCapabilities: {
+          mcpCapabilities: {
+            http: scenario !== "no_http",
+            sse: false,
+          },
+        },
+      },
+    });
+    return;
+  }
+  if (msg.method === "authenticate") {
+    send({ id: msg.id, result: {} });
+    return;
+  }
+  if (msg.method === "session/new") {
+    mcpServers = msg.params?.mcpServers ?? [];
+    process.stderr.write(
+      `__FAKE_ACP_MCP_SERVERS__:${JSON.stringify(mcpServers)}\n`,
+    );
+    send({ id: msg.id, result: sessionNewResult() });
+    return;
+  }
+  if (msg.method === "session/set_config_option") {
+    send({ id: msg.id, result: {} });
+    return;
+  }
+  if (msg.method === "session/prompt") {
+    if (scenario === "process_exit") {
+      setTimeout(() => process.exit(7), 10);
+      return;
+    }
+    const operation = isToolScenario()
+      ? runToolPrompt()
+      : scenario === "builtin_permission"
+        ? runBuiltinPermissionPrompt()
+        : Promise.resolve().then(() => {
+            if (scenario === "with_thought") {
+              update("agent_thought_chunk", {
+                content: { text: "SECRET_THOUGHT" },
+              });
+            }
+            update("agent_message_chunk", {
+              content: { text: "Hello from fake ACP" },
+            });
+          });
+    operation.then(
+      () => send({ id: msg.id, result: {} }),
+      (error) => {
+        process.stderr.write(`__FAKE_ACP_ERROR__:${error.stack ?? error}\n`);
+        send({
+          id: msg.id,
+          error: { code: -32603, message: error.message },
+        });
+      },
+    );
+    return;
+  }
+  if (msg.method === "session/cancel") return;
+  send({ id: msg.id, result: {} });
 });

--- a/src/lib/acp-client.test.ts
+++ b/src/lib/acp-client.test.ts
@@ -64,6 +64,21 @@ describe("resolveAcpModelConfigValue", () => {
       ]),
     ).toBe("first[]");
   });
+
+  it("maps CLI ids through their catalog display-name alias", () => {
+    expect(
+      resolveAcpModelConfigValue(
+        "gpt-5.6-sol-high",
+        [
+          {
+            modelId: "gpt-5.6-sol[reasoning=high]",
+            name: "GPT-5.6 Sol High",
+          },
+        ],
+        ["GPT-5.6 Sol High"],
+      ),
+    ).toBe("gpt-5.6-sol[reasoning=high]");
+  });
 });
 
 describe("runAcpSync", () => {

--- a/src/lib/acp-client.ts
+++ b/src/lib/acp-client.ts
@@ -19,6 +19,10 @@ export type AcpRunOptions = {
   env?: Record<string, string | undefined>;
   /** When set, call session/set_config_option for "model" after session/new (ACP session config). */
   model?: string;
+  /** Additional catalog names for model matching (typically `agent --list-models` display name). */
+  modelAliases?: string[];
+  /** Reject a requested model when the ACP catalog cannot match it. */
+  strictModel?: boolean;
   /** Per-request timeout in ms (default 60000). Rejects and clears pending on timeout. */
   requestTimeoutMs?: number;
   /** Spawn options (e.g. windowsVerbatimArguments for cmd.exe fallback on Windows). */
@@ -232,9 +236,23 @@ export type AcpAvailableModel = { modelId: string; name: string };
 export function resolveAcpModelConfigValue(
   displayName: string,
   availableModels: AcpAvailableModel[] | undefined,
+  aliases: readonly string[] = [],
 ): string {
   if (!availableModels?.length) return displayName;
-  const hit = availableModels.find((m) => m.name === displayName);
+  const candidates = new Set(
+    [displayName, ...aliases]
+      .map((value) => value.trim().toLowerCase())
+      .filter(Boolean),
+  );
+  const hit = availableModels.find((model) => {
+    const modelId = model.modelId.trim().toLowerCase();
+    const baseModelId = modelId.replace(/\[.*$/, "");
+    return (
+      candidates.has(model.name.trim().toLowerCase()) ||
+      candidates.has(modelId) ||
+      candidates.has(baseModelId)
+    );
+  });
   if (!hit) {
     debugAcp(
       "ACP model: no catalog match for display name %j; falling back to default[]",
@@ -465,7 +483,17 @@ export function runAcpSync(
           const resolvedModelId = resolveAcpModelConfigValue(
             opts.model,
             sessionResult.models?.availableModels,
+            opts.modelAliases,
           );
+          if (
+            resolvedModelId === "default[]" &&
+            opts.strictModel &&
+            opts.model !== "default"
+          ) {
+            throw new Error(
+              `ACP model catalog has no match for ${JSON.stringify(opts.model)}`,
+            );
+          }
           if (resolvedModelId !== "default" && resolvedModelId !== "default[]") {
             debugAcp("ACP step: session/set_config_option (model)");
             await sendRequest(
@@ -665,7 +693,17 @@ export function runAcpStream(
           const resolvedModelId = resolveAcpModelConfigValue(
             opts.model,
             sessionResult.models?.availableModels,
+            opts.modelAliases,
           );
+          if (
+            resolvedModelId === "default[]" &&
+            opts.strictModel &&
+            opts.model !== "default"
+          ) {
+            throw new Error(
+              `ACP model catalog has no match for ${JSON.stringify(opts.model)}`,
+            );
+          }
           if (resolvedModelId !== "default" && resolvedModelId !== "default[]") {
             debugAcp("ACP step: session/set_config_option (model)");
             await sendRequest(

--- a/src/lib/acp-connection.ts
+++ b/src/lib/acp-connection.ts
@@ -1,0 +1,477 @@
+import { spawn, type ChildProcess } from "node:child_process";
+import * as readline from "node:readline";
+import { debuglog } from "node:util";
+
+import { trackChildProcess } from "./process.js";
+import { DETACH_CHILDREN, killProcessTree } from "./process-tree-kill.js";
+
+const debugAcp = debuglog("cursor-api-proxy:acp");
+
+export type AcpMcpServer =
+  | {
+      type: "http";
+      name: string;
+      url: string;
+      headers?: Array<{ name: string; value: string }>;
+    }
+  | {
+      type?: "stdio";
+      name: string;
+      command: string;
+      args?: string[];
+      env?: Array<{ name: string; value: string }>;
+    };
+
+export type AcpAvailableModel = { modelId: string; name: string };
+
+export type AcpInitializeResult = {
+  protocolVersion?: number;
+  agentCapabilities?: {
+    mcpCapabilities?: { http?: boolean; sse?: boolean };
+    [key: string]: unknown;
+  };
+};
+
+export type AcpSessionResult = {
+  sessionId?: string;
+  models?: { availableModels?: AcpAvailableModel[] };
+};
+
+export type AcpPermissionParams = {
+  sessionId?: string;
+  toolCall?: Record<string, unknown>;
+  options?: Array<{
+    optionId?: string;
+    name?: string;
+    kind?: string;
+  }>;
+};
+
+type JsonRpcMessage = {
+  id?: number | string | null;
+  method?: string;
+  params?: Record<string, unknown>;
+  result?: unknown;
+  error?: { code?: number; message?: string };
+};
+
+type PendingRequest = {
+  resolve: (value: unknown) => void;
+  reject: (error: Error) => void;
+  timer?: ReturnType<typeof setTimeout>;
+};
+
+export type AcpConnectionOptions = {
+  cwd: string;
+  env?: Record<string, string | undefined>;
+  requestTimeoutMs?: number;
+  spawnOptions?: { windowsVerbatimArguments?: boolean };
+  rawDebug?: boolean;
+  signal?: AbortSignal;
+  onAgentTextChunk?: (text: string) => void;
+  onAgentThoughtChunk?: (text: string) => void;
+  onSessionUpdate?: (update: Record<string, unknown>) => void;
+  onPermission?: (
+    params: AcpPermissionParams,
+  ) => string | undefined | Promise<string | undefined>;
+};
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 60_000;
+
+function buildAcpSpawnEnv(
+  extra?: Record<string, string | undefined>,
+): NodeJS.ProcessEnv {
+  const inheritKeys = [
+    "PATH",
+    "PATHEXT",
+    "SystemRoot",
+    "WINDIR",
+    "COMSPEC",
+    "TEMP",
+    "TMP",
+    "USERPROFILE",
+    "USERNAME",
+    "HOME",
+    "HOMEDRIVE",
+    "HOMEPATH",
+    "APPDATA",
+    "LOCALAPPDATA",
+    "PROGRAMFILES",
+    "PROGRAMFILES(X86)",
+    "PROGRAMDATA",
+    "PUBLIC",
+    "NODE_OPTIONS",
+  ];
+  const out: NodeJS.ProcessEnv = {};
+  for (const key of inheritKeys) {
+    const value = process.env[key];
+    if (value !== undefined) out[key] = value;
+  }
+  for (const [key, value] of Object.entries(extra ?? {})) {
+    if (value !== undefined) out[key] = value;
+  }
+  return out;
+}
+
+function parseLine(line: string): JsonRpcMessage | null {
+  const trimmed = line.replace(/\r$/, "").trim();
+  if (!trimmed) return null;
+  try {
+    return JSON.parse(trimmed) as JsonRpcMessage;
+  } catch {
+    return null;
+  }
+}
+
+export function extractAcpContentText(content: unknown): string {
+  if (
+    content &&
+    typeof content === "object" &&
+    !Array.isArray(content) &&
+    typeof (content as { text?: unknown }).text === "string"
+  ) {
+    return (content as { text: string }).text;
+  }
+  if (!Array.isArray(content)) return "";
+  return content
+    .map((part) => {
+      if (!part || typeof part !== "object") return "";
+      const record = part as {
+        text?: unknown;
+        content?: { text?: unknown };
+      };
+      if (typeof record.content?.text === "string") {
+        return record.content.text;
+      }
+      return typeof record.text === "string" ? record.text : "";
+    })
+    .join("");
+}
+
+function selectedOption(
+  params: AcpPermissionParams,
+  preferredKind: string,
+  fallbackId: string,
+): string {
+  return (
+    params.options?.find((option) => option.kind === preferredKind)?.optionId ??
+    params.options?.find((option) => option.optionId === fallbackId)?.optionId ??
+    fallbackId
+  );
+}
+
+export class AcpConnection {
+  readonly child: ChildProcess;
+  readonly #opts: AcpConnectionOptions;
+  readonly #pending = new Map<number, PendingRequest>();
+  readonly #nextId = { current: 1 };
+  readonly #lineReader: readline.Interface;
+  readonly #exitPromise: Promise<number>;
+  #resolveExit!: (code: number) => void;
+  #stderr = "";
+  #closed = false;
+  #spawnError?: Error;
+  #abortHandler?: () => void;
+
+  constructor(
+    command: string,
+    args: readonly string[],
+    opts: AcpConnectionOptions,
+  ) {
+    this.#opts = opts;
+    this.child = spawn(command, [...args], {
+      cwd: opts.cwd,
+      env: buildAcpSpawnEnv(opts.env),
+      stdio: ["pipe", "pipe", "pipe"],
+      windowsVerbatimArguments: opts.spawnOptions?.windowsVerbatimArguments,
+      detached: DETACH_CHILDREN,
+    });
+    trackChildProcess(this.child);
+
+    this.#exitPromise = new Promise<number>((resolve) => {
+      this.#resolveExit = resolve;
+    });
+
+    this.child.stderr?.setEncoding("utf8");
+    this.child.stderr?.on("data", (chunk: string) => {
+      this.#stderr += chunk;
+    });
+
+    this.#lineReader = readline.createInterface({
+      input: this.child.stdout!,
+    });
+    this.#lineReader.on("line", (line) => this.#handleLine(line));
+
+    this.child.once("error", (error) => {
+      this.#spawnError = error;
+      this.#failPending(error);
+    });
+    this.child.once("close", (code) => {
+      this.#closed = true;
+      this.#lineReader.close();
+      this.#opts.signal?.removeEventListener("abort", this.#abortHandler!);
+      this.#failPending(
+        this.#spawnError ??
+          new Error(`ACP child exited with code ${code ?? 1}`),
+      );
+      this.#resolveExit(code ?? 1);
+    });
+
+    this.#abortHandler = () => {
+      void this.close("SIGTERM");
+    };
+    if (opts.signal) {
+      if (opts.signal.aborted) this.#abortHandler();
+      else {
+        opts.signal.addEventListener("abort", this.#abortHandler, {
+          once: true,
+        });
+      }
+    }
+  }
+
+  get stderr(): string {
+    return this.#stderr.trim();
+  }
+
+  get closed(): boolean {
+    return this.#closed;
+  }
+
+  async initialize(): Promise<AcpInitializeResult> {
+    debugAcp("ACP step: initialize");
+    return (await this.request("initialize", {
+      protocolVersion: 1,
+      clientCapabilities: {
+        fs: { readTextFile: false, writeTextFile: false },
+        terminal: false,
+      },
+      clientInfo: { name: "cursor-api-proxy", version: "1.0.0" },
+    })) as AcpInitializeResult;
+  }
+
+  async authenticate(): Promise<void> {
+    debugAcp("ACP step: authenticate");
+    await this.request("authenticate", { methodId: "cursor_login" });
+  }
+
+  async newSession(
+    cwd: string,
+    mcpServers: readonly AcpMcpServer[],
+  ): Promise<AcpSessionResult> {
+    debugAcp("ACP step: session/new");
+    return (await this.request("session/new", {
+      cwd,
+      mcpServers,
+    })) as AcpSessionResult;
+  }
+
+  async setSessionModel(sessionId: string, value: string): Promise<void> {
+    debugAcp("ACP step: session/set_config_option (model)");
+    await this.request("session/set_config_option", {
+      sessionId,
+      configId: "model",
+      value,
+    });
+  }
+
+  prompt(
+    sessionId: string,
+    prompt: string,
+    timeoutMs?: number,
+  ): Promise<unknown> {
+    debugAcp("ACP step: session/prompt");
+    return this.request(
+      "session/prompt",
+      {
+        sessionId,
+        prompt: [{ type: "text", text: prompt }],
+      },
+      timeoutMs,
+    );
+  }
+
+  notify(method: string, params: Record<string, unknown>): void {
+    const stdin = this.child.stdin;
+    if (!stdin || this.#closed) return;
+    stdin.write(`${JSON.stringify({ jsonrpc: "2.0", method, params })}\n`);
+  }
+
+  request(
+    method: string,
+    params: Record<string, unknown>,
+    timeoutMs = this.#opts.requestTimeoutMs ?? DEFAULT_REQUEST_TIMEOUT_MS,
+  ): Promise<unknown> {
+    const stdin = this.child.stdin;
+    if (!stdin || this.#closed) {
+      return Promise.reject(new Error("ACP connection is closed"));
+    }
+    const id = this.#nextId.current++;
+    return new Promise((resolve, reject) => {
+      const pending: PendingRequest = { resolve, reject };
+      if (timeoutMs > 0) {
+        pending.timer = setTimeout(() => {
+          if (!this.#pending.delete(id)) return;
+          reject(new Error(`ACP ${method} timed out after ${timeoutMs}ms`));
+        }, timeoutMs);
+      }
+      this.#pending.set(id, pending);
+      stdin.write(
+        `${JSON.stringify({ jsonrpc: "2.0", id, method, params })}\n`,
+        "utf8",
+        (error) => {
+          if (!error) return;
+          const waiter = this.#pending.get(id);
+          if (!waiter) return;
+          this.#pending.delete(id);
+          if (waiter.timer) clearTimeout(waiter.timer);
+          waiter.reject(error);
+        },
+      );
+    });
+  }
+
+  async cancelSession(sessionId: string): Promise<void> {
+    this.notify("session/cancel", { sessionId });
+  }
+
+  waitForExit(): Promise<number> {
+    return this.#exitPromise;
+  }
+
+  async close(signal: NodeJS.Signals = "SIGKILL"): Promise<void> {
+    if (this.#closed) return;
+    this.#closed = true;
+    this.#opts.signal?.removeEventListener("abort", this.#abortHandler!);
+    this.#failPending(new Error("ACP connection closed"));
+    try {
+      this.child.stdin?.end();
+    } catch {
+      // best effort
+    }
+    killProcessTree(this.child, signal);
+    await Promise.race([
+      this.#exitPromise,
+      new Promise<void>((resolve) => setTimeout(resolve, 1_000)),
+    ]);
+  }
+
+  #handleLine(line: string): void {
+    if (this.#opts.rawDebug) debugAcp("ACP raw: %s", line);
+    const message = parseLine(line);
+    if (!message) return;
+
+    if (
+      message.id != null &&
+      (message.result !== undefined || message.error !== undefined) &&
+      message.method === undefined
+    ) {
+      const id =
+        typeof message.id === "number" ? message.id : Number(message.id);
+      const waiter = Number.isFinite(id) ? this.#pending.get(id) : undefined;
+      if (!waiter) return;
+      this.#pending.delete(id);
+      if (waiter.timer) clearTimeout(waiter.timer);
+      if (message.error) {
+        waiter.reject(new Error(message.error.message ?? "ACP error"));
+      } else {
+        waiter.resolve(message.result);
+      }
+      return;
+    }
+
+    if (message.method === "session/update") {
+      const update = (message.params?.update ?? message.params) as
+        | Record<string, unknown>
+        | undefined;
+      if (!update) return;
+      this.#opts.onSessionUpdate?.(update);
+      const type = update.sessionUpdate;
+      const text = extractAcpContentText(update.content);
+      if (type === "agent_message_chunk" && text) {
+        this.#opts.onAgentTextChunk?.(text);
+      } else if (type === "agent_thought_chunk" && text) {
+        this.#opts.onAgentThoughtChunk?.(text);
+      }
+      return;
+    }
+
+    if (message.method === "session/request_permission" && message.id != null) {
+      void this.#handlePermission(message);
+      return;
+    }
+
+    if (message.id != null && message.method?.startsWith("cursor/")) {
+      this.#handleCursorExtension(message);
+    }
+  }
+
+  async #handlePermission(message: JsonRpcMessage): Promise<void> {
+    const params = (message.params ?? {}) as AcpPermissionParams;
+    let optionId: string | undefined;
+    try {
+      optionId = await this.#opts.onPermission?.(params);
+    } catch {
+      optionId = undefined;
+    }
+    optionId ??= selectedOption(params, "reject_once", "reject-once");
+    this.#respond(message.id!, {
+      outcome: { outcome: "selected", optionId },
+    });
+  }
+
+  #handleCursorExtension(message: JsonRpcMessage): void {
+    const params = message.params ?? {};
+    if (message.method === "cursor/ask_question") {
+      const questions = Array.isArray(params.questions)
+        ? (params.questions as Array<Record<string, unknown>>)
+        : [];
+      this.#respond(message.id!, {
+        outcome: {
+          outcome: "answered",
+          answers: questions.map((question) => {
+            const options = Array.isArray(question.options)
+              ? (question.options as Array<Record<string, unknown>>)
+              : [];
+            return {
+              questionId: String(question.id ?? ""),
+              selectedOptionIds:
+                options.length > 0 ? [String(options[0]?.id ?? "")] : [],
+            };
+          }),
+        },
+      });
+      return;
+    }
+    if (message.method === "cursor/create_plan") {
+      this.#respond(message.id!, { outcome: { outcome: "accepted" } });
+      return;
+    }
+    this.#respond(message.id!, {});
+  }
+
+  #respond(id: number | string, result: Record<string, unknown>): void {
+    const stdin = this.child.stdin;
+    if (!stdin || this.#closed) return;
+    stdin.write(`${JSON.stringify({ jsonrpc: "2.0", id, result })}\n`);
+  }
+
+  #failPending(error: Error): void {
+    for (const [id, waiter] of this.#pending) {
+      this.#pending.delete(id);
+      if (waiter.timer) clearTimeout(waiter.timer);
+      waiter.reject(error);
+    }
+  }
+}
+
+export function permissionOption(
+  params: AcpPermissionParams,
+  kind: "allow_once" | "reject_once",
+): string {
+  return selectedOption(
+    params,
+    kind,
+    kind === "allow_once" ? "allow-once" : "reject-once",
+  );
+}

--- a/src/lib/acp-tool-session.test.ts
+++ b/src/lib/acp-tool-session.test.ts
@@ -1,0 +1,201 @@
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { AcpToolSession } from "./acp-tool-session.js";
+import type { ClientToolDefinition } from "./tool-types.js";
+
+const node = process.execPath;
+const cwd = process.cwd();
+const fakeServerPath = join(
+  cwd,
+  "src",
+  "lib",
+  "__tests__",
+  "fake-acp-server.mjs",
+);
+
+const sessions: AcpToolSession[] = [];
+
+function createSession(
+  scenario: string,
+  tools: ClientToolDefinition[] = [
+    {
+      name: "weather",
+      description: "Get weather",
+      inputSchema: {
+        type: "object",
+        properties: { city: { type: "string" } },
+      },
+    },
+  ],
+  overrides: Partial<ConstructorParameters<typeof AcpToolSession>[0]> = {},
+) {
+  const session = new AcpToolSession({
+    command: node,
+    args: [fakeServerPath],
+    cwd,
+    env: { FAKE_ACP_SCENARIO: scenario },
+    timeoutMs: 5_000,
+    skipAuthenticate: true,
+    tools,
+    ...overrides,
+  });
+  sessions.push(session);
+  return session;
+}
+
+afterEach(async () => {
+  await Promise.all(sessions.splice(0).map((session) => session.close()));
+});
+
+describe("AcpToolSession", () => {
+  it("attaches private HTTP MCP and parks tools/call", async () => {
+    const session = createSession("tool_call");
+    await session.start("Use weather");
+
+    const first = await session.collect();
+    expect(first.status).toBe("tool_calls");
+    if (first.status !== "tool_calls") return;
+    expect(first.text).toBe("Checking tools.");
+    expect(first.toolCalls).toHaveLength(1);
+    expect(first.toolCalls[0]).toMatchObject({
+      name: "weather",
+    });
+    expect(JSON.parse(first.toolCalls[0].arguments)).toMatchObject({
+      city: "Paris",
+    });
+
+    const final = await session.resume([
+      { callId: first.toolCalls[0].callId, output: "sunny" },
+    ]);
+    expect(final.status).toBe("completed");
+    expect(final.text).toContain("Tool result: sunny");
+  });
+
+  it("batches parallel tool calls", async () => {
+    const session = createSession("tool_parallel", [
+      {
+        name: "weather",
+        inputSchema: { type: "object", properties: {} },
+      },
+      {
+        name: "time",
+        inputSchema: { type: "object", properties: {} },
+      },
+    ]);
+    await session.start("Use both tools");
+    const first = await session.collect();
+    expect(first.status).toBe("tool_calls");
+    if (first.status !== "tool_calls") return;
+    expect(first.toolCalls.map((call) => call.name)).toEqual([
+      "weather",
+      "time",
+    ]);
+
+    const final = await session.resume(
+      first.toolCalls.map((call) => ({
+        callId: call.callId,
+        output: `${call.name}-result`,
+      })),
+    );
+    expect(final.status).toBe("completed");
+    expect(final.text).toContain("weather-result, time-result");
+  });
+
+  it("keeps prompt alive across multiple tool rounds", async () => {
+    const session = createSession("tool_two_round");
+    await session.start("Use weather twice");
+    const first = await session.collect();
+    expect(first.status).toBe("tool_calls");
+    if (first.status !== "tool_calls") return;
+
+    const second = await session.resume([
+      { callId: first.toolCalls[0].callId, output: "first" },
+    ]);
+    expect(second.status).toBe("tool_calls");
+    if (second.status !== "tool_calls") return;
+    expect(second.toolCalls[0].callId).not.toBe(first.toolCalls[0].callId);
+
+    const final = await session.resume([
+      { callId: second.toolCalls[0].callId, output: "second" },
+    ]);
+    expect(final.status).toBe("completed");
+    expect(final.text).toContain("first, second");
+  });
+
+  it("rejects ambient built-in permissions", async () => {
+    const session = createSession("builtin_permission");
+    await session.start("Try built-in");
+    const result = await session.collect();
+    expect(result.status).toBe("completed");
+    expect(result.text).toBe("Builtin handled");
+    expect(result.status === "completed" && result.stderr).toContain(
+      '"optionId":"reject-once"',
+    );
+  });
+
+  it("fails clearly when ACP lacks HTTP MCP", async () => {
+    const session = createSession("no_http");
+    await expect(session.start("Use weather")).rejects.toThrow(
+      /does not support HTTP MCP/,
+    );
+  });
+
+  it("maps CLI display name to ACP model id", async () => {
+    const session = createSession("display_model", undefined, {
+      modelCandidates: ["gpt-5.6-sol-high", "GPT-5.6 Sol High"],
+      strictModel: true,
+    });
+    await session.start("Hello");
+    const result = await session.collect();
+    expect(result.status).toBe("completed");
+    expect(result.status === "completed" && result.stderr).toContain(
+      '"value":"gpt-5.6-sol[reasoning=high]"',
+    );
+  });
+
+  it("expires parked tool turns after the configured TTL", async () => {
+    const session = createSession("tool_call", undefined, {
+      timeoutMs: 100,
+    });
+    await session.start("Use weather");
+    const first = await session.collect();
+    expect(first.status).toBe("tool_calls");
+    await new Promise((resolve) => setTimeout(resolve, 180));
+    expect(session.closed).toBe(true);
+  });
+
+  it("fails the live turn when the ACP process exits", async () => {
+    const session = createSession("process_exit");
+    await session.start("Exit");
+    await expect(session.collect()).rejects.toThrow(/exited with code 7/);
+    expect(session.closed).toBe(true);
+  });
+
+  it("cancels the ACP process on caller abort", async () => {
+    const controller = new AbortController();
+    const session = createSession("tool_delay", undefined, {
+      signal: controller.signal,
+    });
+    await session.start("Use weather");
+    const pending = session.collect();
+    controller.abort();
+    await expect(pending).rejects.toThrow(/exited|closed/i);
+    expect(session.closed).toBe(true);
+  });
+
+  it("runs cleanup once on shutdown", async () => {
+    let cleanupCalls = 0;
+    const session = createSession("tool_call", undefined, {
+      onClose: () => {
+        cleanupCalls += 1;
+      },
+    });
+    await session.start("Use weather");
+    const first = await session.collect();
+    expect(first.status).toBe("tool_calls");
+    await session.close();
+    await session.close();
+    expect(cleanupCalls).toBe(1);
+  });
+});

--- a/src/lib/acp-tool-session.ts
+++ b/src/lib/acp-tool-session.ts
@@ -1,0 +1,329 @@
+import {
+  AcpConnection,
+  permissionOption,
+  type AcpConnectionOptions,
+  type AcpPermissionParams,
+  type AcpSessionResult,
+} from "./acp-connection.js";
+import { resolveAcpModelConfigValue } from "./acp-client.js";
+import { ClientToolBridge } from "./client-tool-bridge.js";
+import type {
+  ClientToolDefinition,
+  ClientToolOutput,
+  PendingClientToolCall,
+} from "./tool-types.js";
+
+const TOOL_BATCH_IDLE_MS = 50;
+
+export type ToolTurnEvent =
+  | { type: "text"; text: string }
+  | { type: "reasoning"; text: string };
+
+export type ToolTurnResult =
+  | {
+      status: "tool_calls";
+      text: string;
+      reasoning: string;
+      toolCalls: PendingClientToolCall[];
+    }
+  | {
+      status: "completed";
+      text: string;
+      reasoning: string;
+      toolCalls: [];
+      stderr: string;
+    };
+
+export type AcpToolSessionOptions = {
+  command: string;
+  args: readonly string[];
+  cwd: string;
+  env?: Record<string, string | undefined>;
+  timeoutMs: number;
+  spawnOptions?: { windowsVerbatimArguments?: boolean };
+  skipAuthenticate?: boolean;
+  rawDebug?: boolean;
+  signal?: AbortSignal;
+  modelCandidates?: string[];
+  strictModel?: boolean;
+  tools: readonly ClientToolDefinition[];
+  requireToolCall?: boolean;
+  maxParallelToolCalls?: number;
+  onClose?: () => void | Promise<void>;
+};
+
+function record(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function toolCallId(value: unknown): string | undefined {
+  const rec = record(value);
+  return typeof rec?.toolCallId === "string" ? rec.toolCallId : undefined;
+}
+
+export class AcpToolSession {
+  readonly bridge: ClientToolBridge;
+
+  readonly #opts: AcpToolSessionOptions;
+  readonly #toolUpdates = new Map<string, Record<string, unknown>>();
+  #connection?: AcpConnection;
+  #sessionId?: string;
+  #promptDone?: Promise<{ ok: true } | { ok: false; error: Error }>;
+  #text = "";
+  #reasoning = "";
+  #listener?: (event: ToolTurnEvent) => void;
+  #ttl?: ReturnType<typeof setTimeout>;
+  #closed = false;
+  #terminal = false;
+
+  constructor(opts: AcpToolSessionOptions) {
+    this.#opts = opts;
+    this.bridge = new ClientToolBridge(opts.tools);
+  }
+
+  async start(prompt: string): Promise<void> {
+    await this.bridge.start();
+    try {
+      const connectionOptions: AcpConnectionOptions = {
+        cwd: this.#opts.cwd,
+        env: this.#opts.env,
+        requestTimeoutMs: this.#opts.timeoutMs,
+        spawnOptions: this.#opts.spawnOptions,
+        rawDebug: this.#opts.rawDebug,
+        signal: this.#opts.signal,
+        onAgentTextChunk: (text) => {
+          this.#text += text;
+          this.#listener?.({ type: "text", text });
+        },
+        onAgentThoughtChunk: (text) => {
+          this.#reasoning += text;
+          this.#listener?.({ type: "reasoning", text });
+        },
+        onSessionUpdate: (update) => {
+          const id = toolCallId(update);
+          if (!id) return;
+          const prior = this.#toolUpdates.get(id) ?? {};
+          this.#toolUpdates.set(id, { ...prior, ...update });
+        },
+        onPermission: (params) => this.#permissionFor(params),
+      };
+      this.#connection = new AcpConnection(
+        this.#opts.command,
+        this.#opts.args,
+        connectionOptions,
+      );
+      const initialized = await this.#connection.initialize();
+      if (initialized.agentCapabilities?.mcpCapabilities?.http !== true) {
+        throw new Error(
+          "Installed Cursor ACP agent does not support HTTP MCP servers",
+        );
+      }
+      if (!this.#opts.skipAuthenticate) {
+        await this.#connection.authenticate();
+      }
+      const session = await this.#connection.newSession(this.#opts.cwd, [
+        this.bridge.mcpServer,
+      ]);
+      this.#sessionId = session.sessionId;
+      if (!this.#sessionId) throw new Error("ACP session/new returned no sessionId");
+      await this.#setModel(session);
+      this.#armTtl();
+      this.#promptDone = this.#connection
+        .prompt(this.#sessionId, prompt, 0)
+        .then(() => ({ ok: true }) as const)
+        .catch((error: unknown) => ({
+          ok: false as const,
+          error: error instanceof Error ? error : new Error(String(error)),
+        }));
+    } catch (error) {
+      await this.close();
+      throw error;
+    }
+  }
+
+  get terminal(): boolean {
+    return this.#terminal;
+  }
+
+  get closed(): boolean {
+    return this.#closed;
+  }
+
+  hasCall(callId: string): boolean {
+    return this.bridge.has(callId);
+  }
+
+  pendingCalls(): PendingClientToolCall[] {
+    return this.bridge.pendingCalls();
+  }
+
+  async collect(
+    listener?: (event: ToolTurnEvent) => void,
+  ): Promise<ToolTurnResult> {
+    if (!this.#promptDone) throw new Error("ACP tool session has not started");
+    if (this.#closed) throw new Error("ACP tool session is closed");
+    this.#listener = listener;
+    this.#armTtl();
+
+    const abort = new AbortController();
+    const pendingBatch = this.#waitForToolBatch(abort.signal);
+    const winner = await Promise.race([
+      this.#promptDone.then((result) => ({ type: "prompt" as const, result })),
+      pendingBatch.then((result) => ({ type: "tools" as const, result })),
+    ]);
+    abort.abort();
+    this.#listener = undefined;
+
+    if (winner.type === "tools" && winner.result === "ready") {
+      const calls = this.bridge.pendingCalls();
+      if (calls.length > 0) {
+        if (
+          this.#opts.maxParallelToolCalls != null &&
+          calls.length > this.#opts.maxParallelToolCalls
+        ) {
+          await this.close();
+          throw new Error(
+            `Agent emitted ${calls.length} parallel tool calls; maximum is ${this.#opts.maxParallelToolCalls}`,
+          );
+        }
+        this.bridge.markExposed(calls.map((call) => call.callId));
+        const { text, reasoning } = this.#drainOutput();
+        return { status: "tool_calls", text, reasoning, toolCalls: calls };
+      }
+    }
+
+    const promptResult =
+      winner.type === "prompt" ? winner.result : await this.#promptDone;
+    if (!promptResult.ok) {
+      await this.close();
+      throw promptResult.error;
+    }
+    if (this.#opts.requireToolCall && this.bridge.totalCalls === 0) {
+      await this.close();
+      throw new Error("Agent completed without the required tool call");
+    }
+    this.#terminal = true;
+    const { text, reasoning } = this.#drainOutput();
+    const stderr = this.#connection?.stderr ?? "";
+    await this.close();
+    return {
+      status: "completed",
+      text,
+      reasoning,
+      toolCalls: [],
+      stderr,
+    };
+  }
+
+  async resume(
+    outputs: readonly ClientToolOutput[],
+    listener?: (event: ToolTurnEvent) => void,
+  ): Promise<ToolTurnResult> {
+    if (outputs.length === 0) {
+      throw new Error("No tool outputs supplied");
+    }
+    this.bridge.resolveOutputs(outputs);
+    return this.collect(listener);
+  }
+
+  async close(): Promise<void> {
+    if (this.#closed) return;
+    this.#closed = true;
+    if (this.#ttl) clearTimeout(this.#ttl);
+    this.#listener = undefined;
+    this.bridge.rejectAll(new Error("ACP tool session closed"));
+    if (this.#connection && this.#sessionId) {
+      await this.#connection.cancelSession(this.#sessionId).catch(() => undefined);
+    }
+    await this.#connection?.close("SIGKILL").catch(() => undefined);
+    await this.bridge.close().catch(() => undefined);
+    await this.#opts.onClose?.();
+  }
+
+  async #setModel(session: AcpSessionResult): Promise<void> {
+    if (!this.#connection || !this.#sessionId) return;
+    const candidates = (this.#opts.modelCandidates ?? []).filter(Boolean);
+    if (candidates.length === 0) return;
+    const available = session.models?.availableModels;
+    let resolved: string | undefined;
+    for (const candidate of candidates) {
+      const value = resolveAcpModelConfigValue(candidate, available);
+      if (value !== "default" && value !== "default[]") {
+        resolved = value;
+        break;
+      }
+    }
+    if (!resolved) {
+      if (this.#opts.strictModel) {
+        throw new Error(
+          `ACP model catalog has no match for ${JSON.stringify(candidates[0])}`,
+        );
+      }
+      return;
+    }
+    await this.#connection.setSessionModel(this.#sessionId, resolved);
+  }
+
+  #permissionFor(params: AcpPermissionParams): string {
+    const call = record(params.toolCall) ?? {};
+    const id = toolCallId(call);
+    const merged = id ? { ...(this.#toolUpdates.get(id) ?? {}), ...call } : call;
+    const payload = JSON.stringify(merged).toLowerCase();
+    const title =
+      typeof merged.title === "string" ? merged.title.trim().toLowerCase() : "";
+    const kind =
+      typeof merged.kind === "string" ? merged.kind.trim().toLowerCase() : "";
+    const proxyOwned =
+      this.bridge.listed &&
+      kind === "other" &&
+      (title === "mcp: tool" ||
+        payload.includes(this.bridge.serverName.toLowerCase()));
+    return permissionOption(
+      params,
+      proxyOwned ? "allow_once" : "reject_once",
+    );
+  }
+
+  #drainOutput(): { text: string; reasoning: string } {
+    const text = this.#text.trim();
+    const reasoning = this.#reasoning.trim();
+    this.#text = "";
+    this.#reasoning = "";
+    return { text, reasoning };
+  }
+
+  #waitForToolBatch(signal: AbortSignal): Promise<"ready" | "aborted"> {
+    return new Promise((resolve) => {
+      let timer: ReturnType<typeof setTimeout> | undefined;
+      const cleanup = () => {
+        if (timer) clearTimeout(timer);
+        unsubscribe();
+        signal.removeEventListener("abort", onAbort);
+      };
+      const finish = (value: "ready" | "aborted") => {
+        cleanup();
+        resolve(value);
+      };
+      const arm = () => {
+        if (this.bridge.pendingCalls().length === 0) return;
+        if (timer) clearTimeout(timer);
+        timer = setTimeout(() => finish("ready"), TOOL_BATCH_IDLE_MS);
+      };
+      const onAbort = () => finish("aborted");
+      const unsubscribe = this.bridge.onCall(arm);
+      signal.addEventListener("abort", onAbort, { once: true });
+      arm();
+    });
+  }
+
+  #armTtl(): void {
+    if (this.#ttl) clearTimeout(this.#ttl);
+    if (this.#opts.timeoutMs <= 0) return;
+    this.#ttl = setTimeout(() => {
+      void this.close();
+    }, this.#opts.timeoutMs);
+    this.#ttl.unref?.();
+  }
+}

--- a/src/lib/agent-runner.ts
+++ b/src/lib/agent-runner.ts
@@ -1,9 +1,11 @@
 import * as fs from "node:fs";
 
 import { runAcpStream, runAcpSync } from "./acp-client.js";
+import { AcpToolSession } from "./acp-tool-session.js";
 import type { BridgeConfig } from "./config.js";
 import type { CursorExecutionMode } from "./execution-mode.js";
 import { run, runStreaming } from "./process.js";
+import type { ClientToolDefinition } from "./tool-types.js";
 import { getChatOnlyEnvOverrides } from "./workspace.js";
 import { readKeychainToken, writeCachedToken } from "./token-cache.js";
 
@@ -52,6 +54,31 @@ function extractModeFromCmdArgs(cmdArgs: string[]): CursorExecutionMode {
   return "ask";
 }
 
+function acpInvocation(
+  config: BridgeConfig,
+  workspaceDir: string,
+  effectiveChatOnly: boolean,
+  cmdArgs: string[],
+  configDir?: string,
+): {
+  args: string[];
+  env: Record<string, string | undefined>;
+  model?: string;
+} {
+  const model = extractModelFromCmdArgs(cmdArgs);
+  const mode = extractModeFromCmdArgs(cmdArgs);
+  let args = acpArgsWithWorkspace(config.acpArgs, workspaceDir);
+  args = model ? acpArgsWithModel(args, model) : args;
+  args = acpArgsWithMode(args, mode);
+  const env = { ...config.acpEnv };
+  if (effectiveChatOnly) {
+    Object.assign(env, getChatOnlyEnvOverrides(workspaceDir, configDir));
+  } else if (configDir) {
+    env.CURSOR_CONFIG_DIR = configDir;
+  }
+  return { args, env, model };
+}
+
 export function runAgentSync(
   config: BridgeConfig,
   workspaceDir: string,
@@ -61,22 +88,23 @@ export function runAgentSync(
   stdinPrompt?: string,
   configDir?: string,
   signal?: AbortSignal,
+  modelDisplayName?: string,
 ): Promise<AgentRunResult> {
   if (config.useAcp && typeof stdinPrompt === "string") {
-    const acpModel = extractModelFromCmdArgs(cmdArgs);
-    const acpMode = extractModeFromCmdArgs(cmdArgs);
-    let args = acpArgsWithWorkspace(config.acpArgs, workspaceDir);
-    args = acpModel ? acpArgsWithModel(args, acpModel) : args;
-    args = acpArgsWithMode(args, acpMode);
-    const acpEnv = { ...config.acpEnv };
-    if (effectiveChatOnly) {
-      Object.assign(acpEnv, getChatOnlyEnvOverrides(workspaceDir, configDir));
-    }
-    return runAcpSync(config.acpCommand, args, stdinPrompt, {
+    const invocation = acpInvocation(
+      config,
+      workspaceDir,
+      effectiveChatOnly,
+      cmdArgs,
+      configDir,
+    );
+    return runAcpSync(config.acpCommand, invocation.args, stdinPrompt, {
       cwd: workspaceDir,
       timeoutMs: config.timeoutMs,
-      env: acpEnv,
-      model: acpModel,
+      env: invocation.env,
+      model: invocation.model,
+      modelAliases: modelDisplayName ? [modelDisplayName] : undefined,
+      strictModel: config.strictModel,
       requestTimeoutMs: config.timeoutMs,
       spawnOptions: config.acpSpawnOptions,
       skipAuthenticate: config.acpSkipAuthenticate,
@@ -130,26 +158,27 @@ export function runAgentStream(
   stdinPrompt?: string,
   configDir?: string,
   signal?: AbortSignal,
+  modelDisplayName?: string,
 ): Promise<{ code: number; stderr: string }> {
   if (config.useAcp && typeof stdinPrompt === "string") {
-    const acpModel = extractModelFromCmdArgs(cmdArgs);
-    const acpMode = extractModeFromCmdArgs(cmdArgs);
-    let args = acpArgsWithWorkspace(config.acpArgs, workspaceDir);
-    args = acpModel ? acpArgsWithModel(args, acpModel) : args;
-    args = acpArgsWithMode(args, acpMode);
-    const acpEnv = { ...config.acpEnv };
-    if (effectiveChatOnly) {
-      Object.assign(acpEnv, getChatOnlyEnvOverrides(workspaceDir, configDir));
-    }
+    const invocation = acpInvocation(
+      config,
+      workspaceDir,
+      effectiveChatOnly,
+      cmdArgs,
+      configDir,
+    );
     return runAcpStream(
       config.acpCommand,
-      args,
+      invocation.args,
       stdinPrompt,
       {
         cwd: workspaceDir,
         timeoutMs: config.timeoutMs,
-        env: acpEnv,
-        model: acpModel,
+        env: invocation.env,
+        model: invocation.model,
+        modelAliases: modelDisplayName ? [modelDisplayName] : undefined,
+        strictModel: config.strictModel,
         requestTimeoutMs: config.timeoutMs,
         spawnOptions: config.acpSpawnOptions,
         skipAuthenticate: config.acpSkipAuthenticate,
@@ -192,4 +221,70 @@ export function runAgentStream(
     }
     return result;
   });
+}
+
+export async function startAgentToolSession(opts: {
+  config: BridgeConfig;
+  workspaceDir: string;
+  effectiveChatOnly: boolean;
+  cmdArgs: string[];
+  prompt: string;
+  tools: readonly ClientToolDefinition[];
+  tempDir?: string;
+  configDir?: string;
+  signal?: AbortSignal;
+  modelDisplayName?: string;
+  requireToolCall?: boolean;
+  maxParallelToolCalls?: number;
+}): Promise<AcpToolSession> {
+  if (!opts.config.useAcp) {
+    throw new Error("Structured tool passthrough requires ACP mode");
+  }
+  const invocation = acpInvocation(
+    opts.config,
+    opts.workspaceDir,
+    opts.effectiveChatOnly,
+    opts.cmdArgs,
+    opts.configDir,
+  );
+  let cleaned = false;
+  const cleanup = () => {
+    if (cleaned) return;
+    cleaned = true;
+    cacheTokenForAccount(opts.configDir);
+    if (opts.tempDir) {
+      try {
+        fs.rmSync(opts.tempDir, { recursive: true, force: true });
+      } catch {
+        // best effort
+      }
+    }
+  };
+  const session = new AcpToolSession({
+    command: opts.config.acpCommand,
+    args: invocation.args,
+    cwd: opts.workspaceDir,
+    env: invocation.env,
+    timeoutMs: opts.config.timeoutMs,
+    spawnOptions: opts.config.acpSpawnOptions,
+    skipAuthenticate: opts.config.acpSkipAuthenticate,
+    rawDebug: opts.config.acpRawDebug,
+    signal: opts.signal,
+    modelCandidates: [
+      invocation.model,
+      opts.modelDisplayName,
+    ].filter((value): value is string => Boolean(value)),
+    strictModel: opts.config.strictModel,
+    tools: opts.tools,
+    requireToolCall: opts.requireToolCall,
+    maxParallelToolCalls: opts.maxParallelToolCalls,
+    onClose: cleanup,
+  });
+  try {
+    await session.start(opts.prompt);
+    return session;
+  } catch (error) {
+    cleanup();
+    throw error;
+  }
 }

--- a/src/lib/anthropic.ts
+++ b/src/lib/anthropic.ts
@@ -7,7 +7,18 @@ import { buildPromptFromMessages } from "./openai.js";
 
 export type AnthropicMessageParam = {
   role: "user" | "assistant";
-  content: string | Array<{ type?: string; text?: string }>;
+  content:
+    | string
+    | Array<{
+        type?: string;
+        text?: string;
+        id?: string;
+        name?: string;
+        input?: unknown;
+        tool_use_id?: string;
+        content?: unknown;
+        is_error?: boolean;
+      }>;
 };
 
 export type AnthropicMessagesRequest = {
@@ -18,6 +29,14 @@ export type AnthropicMessagesRequest = {
   messages: AnthropicMessageParam[];
   system?: string | Array<{ type?: string; text?: string }>;
   stream?: boolean;
+  tools?: Array<{
+    name: string;
+    description?: string;
+    input_schema: Record<string, unknown>;
+  }>;
+  tool_choice?:
+    | { type: "auto" | "any" | "none"; disable_parallel_tool_use?: boolean }
+    | { type: "tool"; name: string; disable_parallel_tool_use?: boolean };
 };
 
 function systemToText(system: AnthropicMessagesRequest["system"]): string {

--- a/src/lib/client-tool-bridge.ts
+++ b/src/lib/client-tool-bridge.ts
@@ -1,0 +1,287 @@
+import { randomBytes, randomUUID, timingSafeEqual } from "node:crypto";
+import * as http from "node:http";
+
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import {
+  CallToolRequestSchema,
+  ErrorCode,
+  ListToolsRequestSchema,
+  McpError,
+} from "@modelcontextprotocol/sdk/types.js";
+
+import type {
+  ClientToolDefinition,
+  ClientToolOutput,
+  PendingClientToolCall,
+} from "./tool-types.js";
+
+type ToolCallResult = {
+  content: Array<{ type: "text"; text: string }>;
+  isError?: boolean;
+};
+
+type ParkedCall = PendingClientToolCall & {
+  exposed: boolean;
+  resolve: (result: ToolCallResult) => void;
+  reject: (error: Error) => void;
+};
+
+export type AcpHttpMcpServer = {
+  type: "http";
+  name: string;
+  url: string;
+  headers: Array<{ name: string; value: string }>;
+};
+
+const LOOPBACK_ADDRESSES = new Set([
+  "127.0.0.1",
+  "::1",
+  "::ffff:127.0.0.1",
+]);
+
+function safeTokenEqual(actual: string, expected: string): boolean {
+  const a = Buffer.from(actual);
+  const b = Buffer.from(expected);
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+
+/**
+ * Per-agent-turn MCP server. It exposes caller-provided schemas but never
+ * executes them. tools/call is parked until the HTTP API caller submits the
+ * corresponding tool result.
+ */
+export class ClientToolBridge {
+  readonly serverName: string;
+
+  readonly #definitions: ClientToolDefinition[];
+  readonly #definitionNames: Set<string>;
+  readonly #token = randomBytes(32).toString("base64url");
+  readonly #path = `/mcp/${randomUUID()}`;
+  readonly #mcp: Server;
+  readonly #transport: StreamableHTTPServerTransport;
+  readonly #httpServer: http.Server;
+  readonly #pending = new Map<string, ParkedCall>();
+  readonly #callListeners = new Set<() => void>();
+  #url?: string;
+  #closed = false;
+  #listed = false;
+  #totalCalls = 0;
+
+  constructor(definitions: readonly ClientToolDefinition[]) {
+    this.#definitions = [...definitions];
+    this.#definitionNames = new Set(definitions.map((tool) => tool.name));
+    this.serverName = `cursor-api-proxy-${randomUUID().slice(0, 8)}`;
+
+    this.#mcp = new Server(
+      { name: this.serverName, version: "1.0.0" },
+      { capabilities: { tools: {} } },
+    );
+    this.#transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+      enableJsonResponse: true,
+    });
+
+    this.#mcp.setRequestHandler(ListToolsRequestSchema, async () => {
+      this.#listed = true;
+      return {
+        tools: this.#definitions.map((tool) => ({
+          name: tool.name,
+          ...(tool.description ? { description: tool.description } : {}),
+          inputSchema: tool.inputSchema,
+        })),
+      };
+    });
+
+    this.#mcp.setRequestHandler(CallToolRequestSchema, async (request) => {
+      const { name, arguments: args } = request.params;
+      if (!this.#definitionNames.has(name)) {
+        throw new McpError(ErrorCode.InvalidParams, `Unknown tool: ${name}`);
+      }
+      if (this.#closed) {
+        throw new McpError(ErrorCode.InternalError, "Tool bridge is closed");
+      }
+
+      const callId = `call_${randomUUID().replace(/-/g, "")}`;
+      const itemId = `fc_${randomUUID().replace(/-/g, "")}`;
+      let argumentsJson = "{}";
+      try {
+        argumentsJson = JSON.stringify(args ?? {});
+      } catch {
+        throw new McpError(
+          ErrorCode.InvalidParams,
+          `Arguments for ${name} are not JSON serializable`,
+        );
+      }
+
+      return new Promise<ToolCallResult>((resolve, reject) => {
+        this.#totalCalls += 1;
+        this.#pending.set(callId, {
+          callId,
+          itemId,
+          name,
+          arguments: argumentsJson,
+          exposed: false,
+          resolve,
+          reject,
+        });
+        for (const listener of this.#callListeners) listener();
+      });
+    });
+
+    this.#httpServer = http.createServer((req, res) => {
+      const remote = req.socket.remoteAddress ?? "";
+      if (!LOOPBACK_ADDRESSES.has(remote)) {
+        res.writeHead(403).end("Forbidden");
+        return;
+      }
+      const url = new URL(req.url ?? "/", "http://127.0.0.1");
+      const auth = req.headers.authorization ?? "";
+      if (
+        url.pathname !== this.#path ||
+        !safeTokenEqual(auth, `Bearer ${this.#token}`)
+      ) {
+        res.writeHead(404).end("Not found");
+        return;
+      }
+      void this.#transport.handleRequest(req, res).catch((error) => {
+        if (!res.headersSent) {
+          res.writeHead(500, { "content-type": "application/json" });
+          res.end(
+            JSON.stringify({
+              jsonrpc: "2.0",
+              id: null,
+              error: {
+                code: -32603,
+                message:
+                  error instanceof Error ? error.message : "MCP bridge error",
+              },
+            }),
+          );
+        } else if (!res.writableEnded) {
+          res.end();
+        }
+      });
+    });
+  }
+
+  async start(): Promise<void> {
+    if (this.#url) return;
+    await this.#mcp.connect(this.#transport);
+    await new Promise<void>((resolve, reject) => {
+      const onError = (error: Error) => {
+        this.#httpServer.off("listening", onListening);
+        reject(error);
+      };
+      const onListening = () => {
+        this.#httpServer.off("error", onError);
+        resolve();
+      };
+      this.#httpServer.once("error", onError);
+      this.#httpServer.once("listening", onListening);
+      this.#httpServer.listen(0, "127.0.0.1");
+    });
+    const address = this.#httpServer.address();
+    if (!address || typeof address === "string") {
+      await this.close();
+      throw new Error("Failed to bind client-tool MCP bridge");
+    }
+    this.#url = `http://127.0.0.1:${address.port}${this.#path}`;
+  }
+
+  get mcpServer(): AcpHttpMcpServer {
+    if (!this.#url) throw new Error("Client-tool MCP bridge has not started");
+    return {
+      type: "http",
+      name: this.serverName,
+      url: this.#url,
+      headers: [
+        { name: "Authorization", value: `Bearer ${this.#token}` },
+      ],
+    };
+  }
+
+  onCall(listener: () => void): () => void {
+    this.#callListeners.add(listener);
+    return () => this.#callListeners.delete(listener);
+  }
+
+  pendingCalls(): PendingClientToolCall[] {
+    return [...this.#pending.values()].map(
+      ({ callId, itemId, name, arguments: args }) => ({
+        callId,
+        itemId,
+        name,
+        arguments: args,
+      }),
+    );
+  }
+
+  unexposedCalls(): PendingClientToolCall[] {
+    return [...this.#pending.values()]
+      .filter((call) => !call.exposed)
+      .map(({ callId, itemId, name, arguments: args }) => ({
+        callId,
+        itemId,
+        name,
+        arguments: args,
+      }));
+  }
+
+  markExposed(callIds: readonly string[]): void {
+    for (const callId of callIds) {
+      const call = this.#pending.get(callId);
+      if (call) call.exposed = true;
+    }
+  }
+
+  has(callId: string): boolean {
+    return this.#pending.has(callId);
+  }
+
+  get listed(): boolean {
+    return this.#listed;
+  }
+
+  get totalCalls(): number {
+    return this.#totalCalls;
+  }
+
+  resolveOutputs(outputs: readonly ClientToolOutput[]): void {
+    for (const output of outputs) {
+      const call = this.#pending.get(output.callId);
+      if (!call) throw new Error(`Unknown tool call_id: ${output.callId}`);
+    }
+    for (const output of outputs) {
+      const call = this.#pending.get(output.callId);
+      if (!call) continue;
+      this.#pending.delete(output.callId);
+      call.resolve({
+        content: [{ type: "text", text: output.output }],
+        ...(output.isError ? { isError: true } : {}),
+      });
+    }
+  }
+
+  rejectAll(error: Error): void {
+    for (const call of this.#pending.values()) call.reject(error);
+    this.#pending.clear();
+  }
+
+  async close(): Promise<void> {
+    if (this.#closed) return;
+    this.#closed = true;
+    this.rejectAll(new Error("Client-tool bridge closed"));
+    this.#callListeners.clear();
+    await this.#transport.close().catch(() => undefined);
+    await this.#mcp.close().catch(() => undefined);
+    if (typeof this.#httpServer.closeAllConnections === "function") {
+      this.#httpServer.closeAllConnections();
+    }
+    if (this.#httpServer.listening) {
+      await new Promise<void>((resolve) => {
+        this.#httpServer.close(() => resolve());
+      });
+    }
+  }
+}

--- a/src/lib/cursor-cli.ts
+++ b/src/lib/cursor-cli.ts
@@ -48,8 +48,25 @@ export async function listCursorCliModels(args: {
   });
 
   if (list.code !== 0) {
-    throw new Error(`agent --list-models failed: ${list.stderr.trim()}`);
+    throw new Error(
+      `Cursor CLI check failed for ${JSON.stringify(
+        args.agentBin,
+      )}: --list-models exited ${list.code}: ${
+        list.stderr.trim() || "no diagnostic output"
+      }. Set CURSOR_AGENT_BIN to the Cursor cursor-agent executable.`,
+    );
   }
 
-  return parseCursorCliModels(list.stdout);
+  const models = parseCursorCliModels(list.stdout);
+  if (models.length === 0) {
+    const sample = stripAnsi(`${list.stdout}\n${list.stderr}`).trim().slice(0, 240);
+    throw new Error(
+      `${JSON.stringify(
+        args.agentBin,
+      )} did not return a Cursor model catalog and may be another vendor's "agent" binary.${
+        sample ? ` Output: ${sample}` : ""
+      } Set CURSOR_AGENT_BIN to the Cursor cursor-agent executable.`,
+    );
+  }
+  return models;
 }

--- a/src/lib/env.test.ts
+++ b/src/lib/env.test.ts
@@ -308,6 +308,58 @@ describe("loadEnvConfig", () => {
   });
 });
 
+describe("agent binary auto-detection", () => {
+  let binDir: string | undefined;
+
+  afterEach(() => {
+    if (binDir) fs.rmSync(binDir, { recursive: true, force: true });
+    binDir = undefined;
+  });
+
+  function executable(name: string): string {
+    binDir ??= fs.mkdtempSync(path.join(os.tmpdir(), "cap-bin-"));
+    const file = path.join(binDir, name);
+    fs.writeFileSync(file, "#!/bin/sh\nexit 0\n");
+    fs.chmodSync(file, 0o755);
+    return file;
+  }
+
+  it("prefers cursor-agent over a conflicting agent binary", () => {
+    const agent = executable("agent");
+    const cursorAgent = executable("cursor-agent");
+    expect(
+      loadEnvConfig({
+        env: { PATH: path.dirname(agent) },
+        platform: "darwin",
+      }).agentBin,
+    ).toBe(cursorAgent);
+  });
+
+  it("falls back to agent when cursor-agent is unavailable", () => {
+    const agent = executable("agent");
+    expect(
+      loadEnvConfig({
+        env: { PATH: path.dirname(agent) },
+        platform: "darwin",
+      }).agentBin,
+    ).toBe(agent);
+  });
+
+  it("honors explicit binary configuration", () => {
+    const agent = executable("agent");
+    executable("cursor-agent");
+    expect(
+      loadEnvConfig({
+        env: {
+          PATH: path.dirname(agent),
+          CURSOR_AGENT_BIN: "/custom/cursor",
+        },
+        platform: "darwin",
+      }).agentBin,
+    ).toBe("/custom/cursor");
+  });
+});
+
 describe("discoverAccountDirs filtering", () => {
   let tmpBase: string;
 

--- a/src/lib/env.ts
+++ b/src/lib/env.ts
@@ -151,6 +151,53 @@ function resolveAbsolutePath(
   return path.resolve(cwd, raw);
 }
 
+function executableOnPath(
+  name: string,
+  env: EnvSource,
+  platform: NodeJS.Platform,
+): string | undefined {
+  const rawPath = env.PATH ?? env.Path ?? env.path;
+  if (!rawPath) return undefined;
+  const extensions =
+    platform === "win32"
+      ? (env.PATHEXT ?? ".EXE;.CMD;.BAT;.COM").split(";")
+      : [""];
+  for (const directory of rawPath.split(path.delimiter).filter(Boolean)) {
+    for (const extension of extensions) {
+      const candidate = path.join(
+        directory,
+        platform === "win32" ? `${name}${extension}` : name,
+      );
+      try {
+        const stat = fs.statSync(candidate);
+        if (!stat.isFile()) continue;
+        if (platform !== "win32") fs.accessSync(candidate, fs.constants.X_OK);
+        return candidate;
+      } catch {
+        // Try the next PATH entry.
+      }
+    }
+  }
+  return undefined;
+}
+
+function resolveAgentBinary(
+  env: EnvSource,
+  platform: NodeJS.Platform,
+): string {
+  const explicit = envString(env, [
+    "CURSOR_AGENT_BIN",
+    "CURSOR_CLI_BIN",
+    "CURSOR_CLI_PATH",
+  ]);
+  if (explicit) return explicit;
+  return (
+    executableOnPath("cursor-agent", env, platform) ??
+    executableOnPath("agent", env, platform) ??
+    "agent"
+  );
+}
+
 /** Version dir name format: YYYY.MM.DD-commit (matches cursor-agent.ps1). */
 const VERSION_DIR_REGEX = /^(\d{4})\.(\d{1,2})\.(\d{1,2})-[a-f0-9]+$/;
 
@@ -279,6 +326,7 @@ function discoverAccountDirs(homeDir: string | undefined): string[] {
 export function loadEnvConfig(opts: EnvOptions = {}): LoadedEnv {
   const env = getEnvSource(opts.env);
   const cwd = getCwd(opts.cwd);
+  const platform = opts.platform ?? process.platform;
 
   const host =
     envString(env, ["CURSOR_BRIDGE_HOST"]) ??
@@ -342,12 +390,7 @@ export function loadEnvConfig(opts: EnvOptions = {}): LoadedEnv {
   const mode = tryParseExecutionModeEnv(firstDefined(env, ["CURSOR_BRIDGE_MODE"]));
 
   return {
-    agentBin:
-      envString(env, [
-        "CURSOR_AGENT_BIN",
-        "CURSOR_CLI_BIN",
-        "CURSOR_CLI_PATH",
-      ]) ?? "agent",
+    agentBin: resolveAgentBinary(env, platform),
     agentNode: envString(env, ["CURSOR_AGENT_NODE"]),
     agentScript: envString(env, ["CURSOR_AGENT_SCRIPT"]),
     commandShell: envString(env, ["COMSPEC"]) ?? "cmd.exe",

--- a/src/lib/handlers/anthropic-messages.ts
+++ b/src/lib/handlers/anthropic-messages.ts
@@ -9,7 +9,12 @@ import {
 } from "../bridge-context-preamble.js";
 import { resolveClientLaunchInfo } from "../client-process.js";
 import { buildAgentFixedArgs } from "../agent-cmd-args.js";
-import { runAgentStream, runAgentSync } from "../agent-runner.js";
+import {
+  runAgentStream,
+  runAgentSync,
+  startAgentToolSession,
+} from "../agent-runner.js";
+import type { ToolTurnEvent, ToolTurnResult } from "../acp-tool-session.js";
 import { createStreamParser } from "../cli-stream-parser.js";
 import type { BridgeConfig } from "../config.js";
 import type { CursorExecutionMode } from "../execution-mode.js";
@@ -45,6 +50,18 @@ import {
   warnPromptTruncated,
 } from "../win-cmdline-limit.js";
 import { abortOnClientDisconnect } from "../client-disconnect.js";
+import {
+  anthropicToolOutputs,
+  parseAnthropicFunctionTools,
+  resolveToolChoice,
+  type PendingClientToolCall,
+} from "../tool-types.js";
+import {
+  ToolSessionError,
+  toolSessionOwnerKey,
+  type ToolSessionRecord,
+  type ToolSessionRegistry,
+} from "../tool-session-registry.js";
 
 function isRateLimited(stderr: string): boolean {
   return /\b429\b|rate.?limit|too many requests/i.test(stderr);
@@ -54,7 +71,166 @@ export type AnthropicMessagesCtx = {
   config: BridgeConfig;
   lastRequestedModelRef: { current?: string };
   modelCacheRef: ModelCacheRef;
+  toolSessions: ToolSessionRegistry;
 };
+
+function anthropicToolUse(call: PendingClientToolCall) {
+  let input: unknown = {};
+  try {
+    input = JSON.parse(call.arguments);
+  } catch {
+    input = {};
+  }
+  return {
+    type: "tool_use",
+    id: call.callId,
+    name: call.name,
+    input,
+  };
+}
+
+function structuredAnthropicResponse(opts: {
+  body: AnthropicMessagesRequest;
+  id: string;
+  model: string | undefined;
+  result: ToolTurnResult;
+  promptLength: number;
+}) {
+  const content: Array<Record<string, unknown>> = [];
+  if (opts.result.text) content.push({ type: "text", text: opts.result.text });
+  if (opts.result.status === "tool_calls") {
+    content.push(...opts.result.toolCalls.map(anthropicToolUse));
+  }
+  return {
+    id: opts.id,
+    type: "message",
+    role: "assistant",
+    model: opts.model,
+    content,
+    stop_reason:
+      opts.result.status === "tool_calls" ? "tool_use" : "end_turn",
+    stop_sequence: null,
+    usage: {
+      input_tokens: Math.max(1, Math.round(opts.promptLength / 4)),
+      output_tokens: Math.max(1, Math.round(opts.result.text.length / 4)),
+    },
+  };
+}
+
+function writeAnthropicEvent(
+  res: http.ServerResponse,
+  event: string,
+  data: Record<string, unknown>,
+): void {
+  res.write(`event: ${event}\ndata: ${JSON.stringify({ type: event, ...data })}\n\n`);
+}
+
+async function writeStructuredAnthropicTurn(opts: {
+  res: http.ServerResponse;
+  body: AnthropicMessagesRequest;
+  stream: boolean;
+  id: string;
+  model: string | undefined;
+  promptLength: number;
+  run: (
+    listener?: (event: ToolTurnEvent) => void,
+  ) => Promise<ToolTurnResult>;
+}): Promise<ToolTurnResult> {
+  if (!opts.stream) {
+    const result = await opts.run();
+    json(
+      opts.res,
+      200,
+      structuredAnthropicResponse({
+        body: opts.body,
+        id: opts.id,
+        model: opts.model,
+        result,
+        promptLength: opts.promptLength,
+      }),
+    );
+    return result;
+  }
+
+  writeSseHeaders(opts.res);
+  writeAnthropicEvent(opts.res, "message_start", {
+    message: {
+      id: opts.id,
+      type: "message",
+      role: "assistant",
+      model: opts.model,
+      content: [],
+      stop_reason: null,
+      stop_sequence: null,
+      usage: {
+        input_tokens: Math.max(1, Math.round(opts.promptLength / 4)),
+        output_tokens: 0,
+      },
+    },
+  });
+
+  let nextIndex = 0;
+  let textIndex: number | undefined;
+  let emittedText = "";
+  const emit = (event: ToolTurnEvent) => {
+    if (event.type !== "text") return;
+    if (event.type === "text") {
+      if (textIndex === undefined) {
+        textIndex = nextIndex++;
+        writeAnthropicEvent(opts.res, "content_block_start", {
+          index: textIndex,
+          content_block: { type: "text", text: "" },
+        });
+      }
+      emittedText += event.text;
+      writeAnthropicEvent(opts.res, "content_block_delta", {
+        index: textIndex,
+        delta: { type: "text_delta", text: event.text },
+      });
+      return;
+    }
+  };
+
+  const result = await opts.run(emit);
+  if (result.text.length > emittedText.length) {
+    emit({ type: "text", text: result.text.slice(emittedText.length) });
+  }
+  if (textIndex !== undefined) {
+    writeAnthropicEvent(opts.res, "content_block_stop", { index: textIndex });
+  }
+  if (result.status === "tool_calls") {
+    for (const call of result.toolCalls) {
+      const index = nextIndex++;
+      writeAnthropicEvent(opts.res, "content_block_start", {
+        index,
+        content_block: {
+          type: "tool_use",
+          id: call.callId,
+          name: call.name,
+          input: {},
+        },
+      });
+      writeAnthropicEvent(opts.res, "content_block_delta", {
+        index,
+        delta: { type: "input_json_delta", partial_json: call.arguments },
+      });
+      writeAnthropicEvent(opts.res, "content_block_stop", { index });
+    }
+  }
+  writeAnthropicEvent(opts.res, "message_delta", {
+    delta: {
+      stop_reason:
+        result.status === "tool_calls" ? "tool_use" : "end_turn",
+      stop_sequence: null,
+    },
+    usage: {
+      output_tokens: Math.max(1, Math.round(result.text.length / 4)),
+    },
+  });
+  writeAnthropicEvent(opts.res, "message_stop", {});
+  opts.res.end();
+  return result;
+}
 
 export async function handleAnthropicMessages(
   req: http.IncomingMessage,
@@ -67,6 +243,51 @@ export async function handleAnthropicMessages(
 ): Promise<void> {
   const { config, lastRequestedModelRef, modelCacheRef } = ctx;
   const body = JSON.parse(rawBody || "{}") as AnthropicMessagesRequest;
+  let selectedTools;
+  let toolInstruction: string | undefined;
+  let requireToolCall = false;
+  let maxParallelToolCalls: number | undefined;
+  let submittedToolOutputs;
+  try {
+    const parsedTools = parseAnthropicFunctionTools(body.tools);
+    const choice = resolveToolChoice(parsedTools, body.tool_choice, {
+      anthropic: true,
+      parallelToolCalls:
+        body.tool_choice?.disable_parallel_tool_use === true
+          ? false
+          : undefined,
+    });
+    selectedTools = choice.tools;
+    toolInstruction = choice.instruction;
+    requireToolCall = choice.required;
+    maxParallelToolCalls = choice.maxParallelToolCalls;
+    submittedToolOutputs = anthropicToolOutputs(body.messages ?? []);
+  } catch (error) {
+    json(res, 400, {
+      error: {
+        type: "invalid_request_error",
+        message: error instanceof Error ? error.message : String(error),
+      },
+    });
+    return;
+  }
+  if (config.useAcp && submittedToolOutputs.length > 0) {
+    const last = body.messages?.[body.messages.length - 1];
+    if (
+      Array.isArray(last?.content) &&
+      last.content.some((block) => block?.type !== "tool_result")
+    ) {
+      json(res, 400, {
+        error: {
+          type: "invalid_request_error",
+          message:
+            "A tool_result resume message cannot contain additional content blocks",
+        },
+      });
+      return;
+    }
+  }
+  const ownerKey = toolSessionOwnerKey(req, remoteAddress);
   const requested = normalizeModelId(body.model);
   const model = resolveModel(requested, lastRequestedModelRef, config);
   const models = await getCachedCursorModels(config, modelCacheRef);
@@ -82,16 +303,37 @@ export async function handleAnthropicMessages(
     decision.requestedWasDefault && config.defaultModel !== "default"
       ? config.defaultModel
       : model;
+  const modelCatalogName = models.find(
+    (item) => item.id === cursorModel,
+  )?.name;
+  const msgId = `msg_${randomUUID().replace(/-/g, "")}`;
 
   const cleanSystem = sanitizeSystem(body.system);
   const cleanMessages = sanitizeMessages(
     body.messages ?? [],
   ) as AnthropicMessagesRequest["messages"];
 
-  const toolsText = toolsToSystemText((body as any).tools);
-  const systemWithTools = toolsText
-    ? [cleanSystem, toolsText].filter(Boolean).join("\n\n")
-    : cleanSystem;
+  const structuredToolStart =
+    config.useAcp &&
+    selectedTools.length > 0 &&
+    submittedToolOutputs.length === 0;
+  const toolsText = structuredToolStart
+    ? undefined
+    : body.tool_choice?.type === "none"
+      ? undefined
+      : toolsToSystemText(body.tools);
+  const cleanSystemText =
+    typeof cleanSystem === "string"
+      ? cleanSystem
+      : (cleanSystem ?? [])
+          .filter(
+            (part: { type?: string; text?: string }) => part?.type === "text",
+          )
+          .map((part: { type?: string; text?: string }) => part.text ?? "")
+          .join("\n");
+  const systemWithTools = [cleanSystemText, toolsText, toolInstruction]
+    .filter(Boolean)
+    .join("\n\n");
   const prompt = buildPromptFromAnthropicMessages(
     cleanMessages,
     systemWithTools as AnthropicMessagesRequest["system"],
@@ -135,6 +377,76 @@ export async function handleAnthropicMessages(
     trafficMessages,
     !!body.stream,
   );
+
+  if (config.useAcp && submittedToolOutputs.length > 0) {
+    const record = ctx.toolSessions.findByCallIds(
+      "anthropic",
+      ownerKey,
+      submittedToolOutputs.map((output) => output.callId),
+    );
+    if (!record) {
+      json(res, 409, {
+        error: {
+          type: "invalid_request_error",
+          message:
+            "Tool session is missing or expired; restart the conversation",
+        },
+      });
+      return;
+    }
+    const configDir = record.configDir;
+    logAccountAssigned(configDir);
+    reportRequestStart(configDir);
+    const startedAt = Date.now();
+    const abortController = new AbortController();
+    abortOnClientDisconnect(res, abortController);
+    abortController.signal.addEventListener(
+      "abort",
+      () => void record.session.close(),
+      { once: true },
+    );
+    try {
+      const result = await writeStructuredAnthropicTurn({
+        res,
+        body,
+        stream: !!body.stream,
+        id: msgId,
+        model: displayModel,
+        promptLength: prompt.length,
+        run: (listener) =>
+          ctx.toolSessions.resume(record, submittedToolOutputs, listener),
+      });
+      reportRequestSuccess(configDir, Date.now() - startedAt);
+      logTrafficResponse(
+        config.verbose,
+        model ?? cursorModel,
+        result.text,
+        !!body.stream,
+      );
+    } catch (error) {
+      reportRequestError(configDir, Date.now() - startedAt);
+      if (!res.headersSent) {
+        json(res, error instanceof ToolSessionError ? error.status : 500, {
+          error: {
+            type: "api_error",
+            message: error instanceof Error ? error.message : String(error),
+          },
+        });
+      } else if (!res.writableEnded) {
+        writeAnthropicEvent(res, "error", {
+          error: {
+            type: "api_error",
+            message: error instanceof Error ? error.message : String(error),
+          },
+        });
+        res.end();
+      }
+    } finally {
+      reportRequestEnd(configDir);
+      logAccountStats(config.verbose, getAccountStats());
+    }
+    return;
+  }
 
   let mode: CursorExecutionMode;
   try {
@@ -218,14 +530,99 @@ export async function handleAnthropicMessages(
   const cmdArgs =
     config.promptViaStdin || config.useAcp ? fixedArgs : fit.args;
 
-  const msgId = `msg_${randomUUID().replace(/-/g, "")}`;
-
   const truncatedHeaders = fit.truncated
     ? { "X-Cursor-Proxy-Prompt-Truncated": "true" }
     : undefined;
 
   const promptForAgent =
     config.promptViaStdin || config.useAcp ? agentPrompt : undefined;
+
+  if (structuredToolStart) {
+    const configDir = getNextAccountConfigDir();
+    logAccountAssigned(configDir);
+    reportRequestStart(configDir);
+    const startedAt = Date.now();
+    const abortController = new AbortController();
+    abortOnClientDisconnect(res, abortController);
+    let record: ToolSessionRecord | undefined;
+    try {
+      const session = await startAgentToolSession({
+        config,
+        workspaceDir,
+        effectiveChatOnly,
+        cmdArgs,
+        prompt: agentPrompt,
+        tools: selectedTools,
+        tempDir,
+        configDir,
+        signal: abortController.signal,
+        modelDisplayName: modelCatalogName,
+        requireToolCall,
+        maxParallelToolCalls,
+      });
+      record = ctx.toolSessions.createRecord({
+        api: "anthropic",
+        ownerKey,
+        model: displayModel ?? cursorModel,
+        configDir,
+        session,
+      });
+      abortController.signal.addEventListener(
+        "abort",
+        () => void session.close(),
+        { once: true },
+      );
+      const result = await writeStructuredAnthropicTurn({
+        res,
+        body,
+        stream: !!body.stream,
+        id: msgId,
+        model: displayModel,
+        promptLength: agentPrompt.length,
+        run: (listener) => ctx.toolSessions.collect(record!, listener),
+      });
+      reportRequestSuccess(configDir, Date.now() - startedAt);
+      if (
+        result.status === "completed" &&
+        result.stderr &&
+        isRateLimited(result.stderr)
+      ) {
+        reportRateLimit(configDir, 60_000);
+      }
+      logTrafficResponse(
+        config.verbose,
+        model ?? cursorModel,
+        result.text,
+        !!body.stream,
+      );
+    } catch (error) {
+      if (record) {
+        ctx.toolSessions.remove(record);
+        await record.session.close().catch(() => undefined);
+      }
+      reportRequestError(configDir, Date.now() - startedAt);
+      if (!res.headersSent) {
+        json(res, 500, {
+          error: {
+            type: "api_error",
+            message: error instanceof Error ? error.message : String(error),
+          },
+        });
+      } else if (!res.writableEnded) {
+        writeAnthropicEvent(res, "error", {
+          error: {
+            type: "api_error",
+            message: error instanceof Error ? error.message : String(error),
+          },
+        });
+        res.end();
+      }
+    } finally {
+      reportRequestEnd(configDir);
+      logAccountStats(config.verbose, getAccountStats());
+    }
+    return;
+  }
 
   if (body.stream) {
     writeSseHeaders(res, truncatedHeaders);
@@ -280,6 +677,7 @@ export async function handleAnthropicMessages(
         promptForAgent,
         configDir,
         abortController.signal,
+        modelCatalogName,
       )
         .then(({ code, stderr: stderrOut }) => {
           const latencyMs = Date.now() - streamStart;
@@ -384,6 +782,7 @@ export async function handleAnthropicMessages(
       promptForAgent,
       configDir,
       abortController.signal,
+      modelCatalogName,
     )
       .then(({ code, stderr: stderrOut }) => {
         const latencyMs = Date.now() - streamStart;
@@ -442,6 +841,7 @@ export async function handleAnthropicMessages(
     promptForAgent,
     configDir,
     abortController.signal,
+    modelCatalogName,
   );
   const syncLatency = Date.now() - syncStart;
   reportRequestEnd(configDir);

--- a/src/lib/handlers/chat-completions.ts
+++ b/src/lib/handlers/chat-completions.ts
@@ -6,7 +6,12 @@ import type { CursorExecutionMode } from "../execution-mode.js";
 import type { ModelCacheRef } from "./models.js";
 import { getCachedCursorModels } from "./models.js";
 import { buildAgentFixedArgs } from "../agent-cmd-args.js";
-import { runAgentStream, runAgentSync } from "../agent-runner.js";
+import {
+  runAgentStream,
+  runAgentSync,
+  startAgentToolSession,
+} from "../agent-runner.js";
+import type { ToolTurnEvent, ToolTurnResult } from "../acp-tool-session.js";
 import { createStreamParser } from "../cli-stream-parser.js";
 import { json, writeSseHeaders } from "../http.js";
 import { resolveModelForExecution } from "../model-map.js";
@@ -44,6 +49,18 @@ import {
   fitPromptToWinCmdline,
   warnPromptTruncated,
 } from "../win-cmdline-limit.js";
+import {
+  chatToolOutputs,
+  parseOpenAiFunctionTools,
+  resolveToolChoice,
+  type PendingClientToolCall,
+} from "../tool-types.js";
+import {
+  ToolSessionError,
+  toolSessionOwnerKey,
+  type ToolSessionRecord,
+  type ToolSessionRegistry,
+} from "../tool-session-registry.js";
 
 function isRateLimited(stderr: string): boolean {
   return /\b429\b|rate.?limit|too many requests/i.test(stderr);
@@ -53,7 +70,154 @@ export type ChatCompletionsCtx = {
   config: BridgeConfig;
   lastRequestedModelRef: { current?: string };
   modelCacheRef: ModelCacheRef;
+  toolSessions: ToolSessionRegistry;
 };
+
+function chatToolCallWire(calls: readonly PendingClientToolCall[]) {
+  return calls.map((call) => ({
+    id: call.callId,
+    type: "function" as const,
+    function: { name: call.name, arguments: call.arguments },
+  }));
+}
+
+function chatToolResponse(opts: {
+  id: string;
+  created: number;
+  model: string | undefined;
+  result: ToolTurnResult;
+  promptLength: number;
+}) {
+  const completionText = opts.result.text;
+  const promptTokens = Math.max(1, Math.round(opts.promptLength / 4));
+  const completionTokens = Math.max(
+    1,
+    Math.round(completionText.length / 4),
+  );
+  const calls =
+    opts.result.status === "tool_calls"
+      ? chatToolCallWire(opts.result.toolCalls)
+      : undefined;
+  return {
+    id: opts.id,
+    object: "chat.completion",
+    created: opts.created,
+    model: opts.model,
+    choices: [
+      {
+        index: 0,
+        message: {
+          role: "assistant",
+          content: completionText || (calls ? null : ""),
+          ...(opts.result.reasoning
+            ? { reasoning_content: opts.result.reasoning }
+            : {}),
+          ...(calls ? { tool_calls: calls } : {}),
+        },
+        finish_reason: calls ? "tool_calls" : "stop",
+      },
+    ],
+    usage: {
+      prompt_tokens: promptTokens,
+      completion_tokens: completionTokens,
+      total_tokens: promptTokens + completionTokens,
+    },
+  };
+}
+
+async function writeStructuredChatTurn(opts: {
+  res: http.ServerResponse;
+  stream: boolean;
+  id: string;
+  created: number;
+  model: string | undefined;
+  promptLength: number;
+  run: (
+    listener?: (event: ToolTurnEvent) => void,
+  ) => Promise<ToolTurnResult>;
+}): Promise<ToolTurnResult> {
+  if (!opts.stream) {
+    const result = await opts.run();
+    json(
+      opts.res,
+      200,
+      chatToolResponse({
+        id: opts.id,
+        created: opts.created,
+        model: opts.model,
+        result,
+        promptLength: opts.promptLength,
+      }),
+    );
+    return result;
+  }
+
+  writeSseHeaders(opts.res);
+  const writeChunk = (
+    delta: Record<string, unknown>,
+    finishReason: string | null = null,
+    usage?: Record<string, number>,
+  ) => {
+    opts.res.write(
+      `data: ${JSON.stringify({
+        id: opts.id,
+        object: "chat.completion.chunk",
+        created: opts.created,
+        model: opts.model,
+        choices: [{ index: 0, delta, finish_reason: finishReason }],
+        ...(usage ? { usage } : {}),
+      })}\n\n`,
+    );
+  };
+  writeChunk({ role: "assistant" });
+  let emittedText = "";
+  let emittedReasoning = "";
+  const result = await opts.run((event) => {
+    if (event.type === "text") {
+      emittedText += event.text;
+      writeChunk({ content: event.text });
+    } else {
+      emittedReasoning += event.text;
+      writeChunk({ reasoning_content: event.text });
+    }
+  });
+  if (result.reasoning.length > emittedReasoning.length) {
+    writeChunk({
+      reasoning_content: result.reasoning.slice(emittedReasoning.length),
+    });
+  }
+  if (result.text.length > emittedText.length) {
+    writeChunk({ content: result.text.slice(emittedText.length) });
+  }
+  if (result.status === "tool_calls") {
+    result.toolCalls.forEach((call, index) => {
+      writeChunk({
+        tool_calls: [
+          {
+            index,
+            id: call.callId,
+            type: "function",
+            function: { name: call.name, arguments: call.arguments },
+          },
+        ],
+      });
+    });
+  }
+  const promptTokens = Math.max(1, Math.round(opts.promptLength / 4));
+  const completionTokens = Math.max(1, Math.round(result.text.length / 4));
+  writeChunk(
+    {},
+    result.status === "tool_calls" ? "tool_calls" : "stop",
+    {
+      prompt_tokens: promptTokens,
+      completion_tokens: completionTokens,
+      total_tokens: promptTokens + completionTokens,
+    },
+  );
+  opts.res.write("data: [DONE]\n\n");
+  opts.res.end();
+  return result;
+}
 
 export async function handleChatCompletions(
   req: http.IncomingMessage,
@@ -66,6 +230,36 @@ export async function handleChatCompletions(
 ): Promise<void> {
   const { config, lastRequestedModelRef, modelCacheRef } = ctx;
   const body = JSON.parse(rawBody || "{}") as OpenAiChatCompletionRequest;
+  let selectedTools;
+  let toolInstruction: string | undefined;
+  let requireToolCall = false;
+  let maxParallelToolCalls: number | undefined;
+  let submittedToolOutputs;
+  try {
+    const parsedTools = parseOpenAiFunctionTools(body.tools, body.functions);
+    const choice = resolveToolChoice(
+      parsedTools,
+      body.tool_choice ?? body.function_call,
+      {
+      parallelToolCalls: (body as any).parallel_tool_calls,
+      },
+    );
+    selectedTools = choice.tools;
+    toolInstruction = choice.instruction;
+    requireToolCall = choice.required;
+    maxParallelToolCalls = choice.maxParallelToolCalls;
+    submittedToolOutputs = chatToolOutputs(body.messages ?? []);
+  } catch (error) {
+    json(res, 400, {
+      error: {
+        message: error instanceof Error ? error.message : String(error),
+        code: "invalid_tools",
+        type: "invalid_request_error",
+      },
+    });
+    return;
+  }
+  const ownerKey = toolSessionOwnerKey(req, remoteAddress);
   const requested = normalizeModelId(body.model);
   const model = resolveModel(requested, lastRequestedModelRef, config);
   const models = await getCachedCursorModels(config, modelCacheRef);
@@ -82,13 +276,30 @@ export async function handleChatCompletions(
     decision.requestedWasDefault && config.defaultModel !== "default"
       ? config.defaultModel
       : model;
+  const modelCatalogName = models.find(
+    (item) => item.id === cursorModel,
+  )?.name;
+  const id = `chatcmpl_${randomUUID().replace(/-/g, "")}`;
+  const created = Math.floor(Date.now() / 1000);
 
   const cleanMessages = sanitizeMessages(body.messages ?? []);
 
-  const toolsText = toolsToSystemText(body.tools, body.functions);
-  const messagesWithTools = toolsText
-    ? [{ role: "system", content: toolsText }, ...cleanMessages]
-    : cleanMessages;
+  const structuredToolStart =
+    config.useAcp &&
+    selectedTools.length > 0 &&
+    submittedToolOutputs.length === 0;
+  const toolsText = structuredToolStart
+    ? undefined
+    : body.tool_choice === "none"
+      ? undefined
+      : toolsToSystemText(body.tools, body.functions);
+  const messagesWithTools = [
+    ...(toolInstruction && structuredToolStart
+      ? [{ role: "system", content: toolInstruction }]
+      : []),
+    ...(toolsText ? [{ role: "system", content: toolsText }] : []),
+    ...cleanMessages,
+  ];
   const prompt = buildPromptFromMessages(messagesWithTools);
 
   const trafficMessages: TrafficMessage[] = cleanMessages.map((m: any) => {
@@ -109,6 +320,83 @@ export async function handleChatCompletions(
     trafficMessages,
     !!body.stream,
   );
+
+  if (config.useAcp && submittedToolOutputs.length > 0) {
+    const record = ctx.toolSessions.findByCallIds(
+      "chat",
+      ownerKey,
+      submittedToolOutputs.map((output) => output.callId),
+    );
+    if (!record) {
+      json(res, 409, {
+        error: {
+          message:
+            "Tool session is missing or expired; restart the conversation",
+          code: "tool_session_expired",
+          type: "invalid_request_error",
+        },
+      });
+      return;
+    }
+    const configDir = record.configDir;
+    logAccountAssigned(configDir);
+    reportRequestStart(configDir);
+    const startedAt = Date.now();
+    const abortController = new AbortController();
+    abortOnClientDisconnect(res, abortController);
+    abortController.signal.addEventListener(
+      "abort",
+      () => void record.session.close(),
+      { once: true },
+    );
+    try {
+      const result = await writeStructuredChatTurn({
+        res,
+        stream: !!body.stream,
+        id,
+        created,
+        model: displayModel,
+        promptLength: prompt.length,
+        run: (listener) =>
+          ctx.toolSessions.resume(record, submittedToolOutputs, listener),
+      });
+      reportRequestSuccess(configDir, Date.now() - startedAt);
+      logTrafficResponse(
+        config.verbose,
+        model ?? cursorModel,
+        result.text,
+        !!body.stream,
+      );
+    } catch (error) {
+      reportRequestError(configDir, Date.now() - startedAt);
+      if (!res.headersSent) {
+        json(res, error instanceof ToolSessionError ? error.status : 500, {
+          error: {
+            message: error instanceof Error ? error.message : String(error),
+            code:
+              error instanceof ToolSessionError
+                ? error.code
+                : "tool_session_error",
+          },
+        });
+      } else if (!res.writableEnded) {
+        res.write(
+          `data: ${JSON.stringify({
+            error: {
+              message: error instanceof Error ? error.message : String(error),
+              code: "tool_session_error",
+            },
+          })}\n\n`,
+        );
+        res.write("data: [DONE]\n\n");
+        res.end();
+      }
+    } finally {
+      reportRequestEnd(configDir);
+      logAccountStats(config.verbose, getAccountStats());
+    }
+    return;
+  }
 
   let mode: CursorExecutionMode;
   try {
@@ -184,15 +472,103 @@ export async function handleChatCompletions(
   const cmdArgs =
     config.promptViaStdin || config.useAcp ? fixedArgs : fit.args;
 
-  const id = `chatcmpl_${randomUUID().replace(/-/g, "")}`;
-  const created = Math.floor(Date.now() / 1000);
-
   const promptForAgent =
     config.promptViaStdin || config.useAcp ? agentPrompt : undefined;
 
   const truncatedHeaders = fit.truncated
     ? { "X-Cursor-Proxy-Prompt-Truncated": "true" }
     : undefined;
+
+  if (structuredToolStart) {
+    const configDir = getNextAccountConfigDir();
+    logAccountAssigned(configDir);
+    reportRequestStart(configDir);
+    const startedAt = Date.now();
+    const abortController = new AbortController();
+    abortOnClientDisconnect(res, abortController);
+    let record: ToolSessionRecord | undefined;
+    try {
+      const session = await startAgentToolSession({
+        config,
+        workspaceDir,
+        effectiveChatOnly,
+        cmdArgs,
+        prompt: agentPrompt,
+        tools: selectedTools,
+        tempDir,
+        configDir,
+        signal: abortController.signal,
+        modelDisplayName: modelCatalogName,
+        requireToolCall,
+        maxParallelToolCalls,
+      });
+      record = ctx.toolSessions.createRecord({
+        api: "chat",
+        ownerKey,
+        model: displayModel ?? cursorModel,
+        configDir,
+        session,
+      });
+      abortController.signal.addEventListener(
+        "abort",
+        () => void session.close(),
+        { once: true },
+      );
+      const result = await writeStructuredChatTurn({
+        res,
+        stream: !!body.stream,
+        id,
+        created,
+        model: displayModel,
+        promptLength: agentPrompt.length,
+        run: (listener) => ctx.toolSessions.collect(record!, listener),
+      });
+      reportRequestSuccess(configDir, Date.now() - startedAt);
+      if (
+        result.status === "completed" &&
+        result.stderr &&
+        isRateLimited(result.stderr)
+      ) {
+        reportRateLimit(configDir, 60_000);
+      }
+      logTrafficResponse(
+        config.verbose,
+        model ?? cursorModel,
+        result.text,
+        !!body.stream,
+      );
+    } catch (error) {
+      if (record) {
+        ctx.toolSessions.remove(record);
+        await record.session.close().catch(() => undefined);
+      }
+      reportRequestError(configDir, Date.now() - startedAt);
+      if (!res.headersSent) {
+        json(res, 500, {
+          error: {
+            message: error instanceof Error ? error.message : String(error),
+            code: "tool_session_error",
+            type: "api_error",
+          },
+        });
+      } else if (!res.writableEnded) {
+        res.write(
+          `data: ${JSON.stringify({
+            error: {
+              message: error instanceof Error ? error.message : String(error),
+              code: "tool_session_error",
+            },
+          })}\n\n`,
+        );
+        res.write("data: [DONE]\n\n");
+        res.end();
+      }
+    } finally {
+      reportRequestEnd(configDir);
+      logAccountStats(config.verbose, getAccountStats());
+    }
+    return;
+  }
 
   if (body.stream) {
     const configDir = getNextAccountConfigDir();
@@ -233,6 +609,7 @@ export async function handleChatCompletions(
         promptForAgent,
         configDir,
         abortController.signal,
+        modelCatalogName,
       )
         .then(({ code, stderr: stderrOut }) => {
           const latencyMs = Date.now() - streamStart;
@@ -375,6 +752,7 @@ export async function handleChatCompletions(
       promptForAgent,
       configDir,
       abortController.signal,
+      modelCatalogName,
     )
       .then(({ code, stderr: stderrOut }) => {
         const latencyMs = Date.now() - streamStart;
@@ -433,6 +811,7 @@ export async function handleChatCompletions(
     promptForAgent,
     configDir,
     abortController.signal,
+    modelCatalogName,
   );
   const syncLatency = Date.now() - syncStart;
   reportRequestEnd(configDir);

--- a/src/lib/handlers/responses.ts
+++ b/src/lib/handlers/responses.ts
@@ -18,7 +18,12 @@ import {
 import type { BridgeConfig } from "../config.js";
 import type { CursorExecutionMode } from "../execution-mode.js";
 import { json, writeSseHeaders } from "../http.js";
-import { runAgentStream, runAgentSync } from "../agent-runner.js";
+import {
+  runAgentStream,
+  runAgentSync,
+  startAgentToolSession,
+} from "../agent-runner.js";
+import type { ToolTurnEvent, ToolTurnResult } from "../acp-tool-session.js";
 import { createStreamParser } from "../cli-stream-parser.js";
 import { resolveModelForExecution } from "../model-map.js";
 import {
@@ -46,6 +51,18 @@ import {
   warnPromptTruncated,
 } from "../win-cmdline-limit.js";
 import { abortOnClientDisconnect } from "../client-disconnect.js";
+import {
+  parseOpenAiFunctionTools,
+  resolveToolChoice,
+  responsesToolOutputs,
+  type PendingClientToolCall,
+} from "../tool-types.js";
+import {
+  ToolSessionError,
+  toolSessionOwnerKey,
+  type ToolSessionRecord,
+  type ToolSessionRegistry,
+} from "../tool-session-registry.js";
 import { getCachedCursorModels, type ModelCacheRef } from "./models.js";
 
 function isRateLimited(stderr: string): boolean {
@@ -56,9 +73,260 @@ export type ResponsesCtx = {
   config: BridgeConfig;
   lastRequestedModelRef: { current?: string };
   modelCacheRef: ModelCacheRef;
+  toolSessions: ToolSessionRegistry;
 };
 
 type ResponseStatus = "in_progress" | "completed" | "failed";
+
+function functionCallItem(call: PendingClientToolCall) {
+  return {
+    id: call.itemId,
+    type: "function_call",
+    status: "completed",
+    call_id: call.callId,
+    name: call.name,
+    arguments: call.arguments,
+  };
+}
+
+function structuredResponseObject(opts: {
+  body: OpenAiResponsesRequest;
+  id: string;
+  createdAt: number;
+  model: string | undefined;
+  result: ToolTurnResult;
+  previousResponseId?: string | null;
+  promptLength: number;
+  messageId?: string;
+}) {
+  const output: Array<Record<string, unknown>> = [];
+  if (opts.result.text) {
+    output.push({
+      id: opts.messageId ?? `msg_${randomUUID().replace(/-/g, "")}`,
+      type: "message",
+      status: "completed",
+      role: "assistant",
+      content: [
+        {
+          type: "output_text",
+          text: opts.result.text,
+          annotations: [],
+        },
+      ],
+    });
+  }
+  if (opts.result.status === "tool_calls") {
+    output.push(...opts.result.toolCalls.map(functionCallItem));
+  }
+  const inputTokens = Math.max(1, Math.round(opts.promptLength / 4));
+  const outputTokens = Math.max(1, Math.round(opts.result.text.length / 4));
+  return {
+    id: opts.id,
+    object: "response",
+    created_at: opts.createdAt,
+    status: "completed",
+    background: false,
+    error: null,
+    incomplete_details: null,
+    instructions: opts.body.instructions ?? null,
+    max_output_tokens: opts.body.max_output_tokens ?? null,
+    model: opts.model,
+    output,
+    output_text: opts.result.text,
+    parallel_tool_calls: opts.body.parallel_tool_calls ?? true,
+    previous_response_id:
+      opts.previousResponseId ?? opts.body.previous_response_id ?? null,
+    reasoning: opts.body.reasoning ?? null,
+    service_tier: opts.body.service_tier ?? "default",
+    store: opts.body.store ?? true,
+    temperature: opts.body.temperature ?? null,
+    text: opts.body.text ?? { format: { type: "text" } },
+    tool_choice: opts.body.tool_choice ?? "auto",
+    tools: opts.body.tools ?? [],
+    top_p: opts.body.top_p ?? null,
+    truncation: opts.body.truncation ?? "disabled",
+    usage: {
+      input_tokens: inputTokens,
+      input_tokens_details: { cached_tokens: 0 },
+      output_tokens: outputTokens,
+      output_tokens_details: { reasoning_tokens: 0 },
+      total_tokens: inputTokens + outputTokens,
+    },
+    user: opts.body.user ?? null,
+    metadata: opts.body.metadata ?? null,
+  };
+}
+
+async function writeStructuredResponseTurn(opts: {
+  res: http.ServerResponse;
+  body: OpenAiResponsesRequest;
+  stream: boolean;
+  id: string;
+  createdAt: number;
+  model: string | undefined;
+  previousResponseId?: string | null;
+  promptLength: number;
+  run: (
+    listener?: (event: ToolTurnEvent) => void,
+  ) => Promise<ToolTurnResult>;
+}): Promise<ToolTurnResult> {
+  const messageId = `msg_${randomUUID().replace(/-/g, "")}`;
+  if (!opts.stream) {
+    const result = await opts.run();
+    json(
+      opts.res,
+      200,
+      structuredResponseObject({
+        body: opts.body,
+        id: opts.id,
+        createdAt: opts.createdAt,
+        model: opts.model,
+        result,
+        previousResponseId: opts.previousResponseId,
+        promptLength: opts.promptLength,
+        messageId,
+      }),
+    );
+    return result;
+  }
+
+  writeSseHeaders(opts.res);
+  const initial = {
+    id: opts.id,
+    object: "response",
+    created_at: opts.createdAt,
+    status: "in_progress",
+    model: opts.model,
+    output: [],
+  };
+  writeResponseEvent(opts.res, "response.created", { response: initial });
+  let textStarted = false;
+  let emittedText = "";
+  const emitText = (text: string) => {
+    if (!textStarted) {
+      textStarted = true;
+      writeResponseEvent(opts.res, "response.output_item.added", {
+        response_id: opts.id,
+        output_index: 0,
+        item: {
+          id: messageId,
+          type: "message",
+          status: "in_progress",
+          role: "assistant",
+          content: [],
+        },
+      });
+      writeResponseEvent(opts.res, "response.content_part.added", {
+        response_id: opts.id,
+        item_id: messageId,
+        output_index: 0,
+        content_index: 0,
+        part: { type: "output_text", text: "", annotations: [] },
+      });
+    }
+    emittedText += text;
+    writeResponseEvent(opts.res, "response.output_text.delta", {
+      response_id: opts.id,
+      item_id: messageId,
+      output_index: 0,
+      content_index: 0,
+      delta: text,
+    });
+  };
+  const result = await opts.run((event) => {
+    if (event.type === "text") emitText(event.text);
+  });
+  if (result.text.length > emittedText.length) {
+    emitText(result.text.slice(emittedText.length));
+  }
+  let outputIndex = textStarted ? 1 : 0;
+  if (textStarted) {
+    writeResponseEvent(opts.res, "response.output_text.done", {
+      response_id: opts.id,
+      item_id: messageId,
+      output_index: 0,
+      content_index: 0,
+      text: result.text,
+    });
+    writeResponseEvent(opts.res, "response.content_part.done", {
+      response_id: opts.id,
+      item_id: messageId,
+      output_index: 0,
+      content_index: 0,
+      part: { type: "output_text", text: result.text, annotations: [] },
+    });
+    writeResponseEvent(opts.res, "response.output_item.done", {
+      response_id: opts.id,
+      output_index: 0,
+      item: {
+        id: messageId,
+        type: "message",
+        status: "completed",
+        role: "assistant",
+        content: [
+          { type: "output_text", text: result.text, annotations: [] },
+        ],
+      },
+    });
+  }
+  if (result.status === "tool_calls") {
+    for (const call of result.toolCalls) {
+      writeResponseEvent(opts.res, "response.output_item.added", {
+        response_id: opts.id,
+        output_index: outputIndex,
+        item: {
+          id: call.itemId,
+          type: "function_call",
+          status: "in_progress",
+          call_id: call.callId,
+          name: call.name,
+          arguments: "",
+        },
+      });
+      writeResponseEvent(
+        opts.res,
+        "response.function_call_arguments.delta",
+        {
+          response_id: opts.id,
+          item_id: call.itemId,
+          output_index: outputIndex,
+          delta: call.arguments,
+        },
+      );
+      writeResponseEvent(
+        opts.res,
+        "response.function_call_arguments.done",
+        {
+          response_id: opts.id,
+          item_id: call.itemId,
+          output_index: outputIndex,
+          arguments: call.arguments,
+        },
+      );
+      writeResponseEvent(opts.res, "response.output_item.done", {
+        response_id: opts.id,
+        output_index: outputIndex,
+        item: functionCallItem(call),
+      });
+      outputIndex += 1;
+    }
+  }
+  writeResponseEvent(opts.res, "response.completed", {
+    response: structuredResponseObject({
+      body: opts.body,
+      id: opts.id,
+      createdAt: opts.createdAt,
+      model: opts.model,
+      result,
+      previousResponseId: opts.previousResponseId,
+      promptLength: opts.promptLength,
+      messageId,
+    }),
+  });
+  opts.res.write("data: [DONE]\n\n");
+  opts.res.end();
+  return result;
+}
 
 function createResponseObject(opts: {
   body: OpenAiResponsesRequest;
@@ -181,6 +449,64 @@ export async function handleResponses(
 ): Promise<void> {
   const { config, lastRequestedModelRef, modelCacheRef } = ctx;
   const body = JSON.parse(rawBody || "{}") as OpenAiResponsesRequest;
+  let selectedTools;
+  let toolInstruction: string | undefined;
+  let requireToolCall = false;
+  let maxParallelToolCalls: number | undefined;
+  let submittedToolOutputs;
+  try {
+    const parsedTools = parseOpenAiFunctionTools(body.tools);
+    const choice = resolveToolChoice(parsedTools, body.tool_choice, {
+      parallelToolCalls: body.parallel_tool_calls,
+    });
+    selectedTools = choice.tools;
+    toolInstruction = choice.instruction;
+    requireToolCall = choice.required;
+    maxParallelToolCalls = choice.maxParallelToolCalls;
+    submittedToolOutputs = responsesToolOutputs(body.input);
+  } catch (error) {
+    json(res, 400, {
+      error: {
+        message: error instanceof Error ? error.message : String(error),
+        code: "invalid_tools",
+        type: "invalid_request_error",
+      },
+    });
+    return;
+  }
+  if (config.useAcp && submittedToolOutputs.length > 0) {
+    if (
+      Array.isArray(body.input) &&
+      body.input.some(
+        (item) =>
+          !item ||
+          typeof item !== "object" ||
+          (item as { type?: unknown }).type !== "function_call_output",
+      )
+    ) {
+      json(res, 400, {
+        error: {
+          message:
+            "A function_call_output resume cannot include other input item types",
+          code: "invalid_tool_resume",
+          type: "invalid_request_error",
+        },
+      });
+      return;
+    }
+    if (body.instructions != null) {
+      json(res, 400, {
+        error: {
+          message:
+            "instructions cannot change while an ACP tool turn is active",
+          code: "invalid_tool_resume",
+          type: "invalid_request_error",
+        },
+      });
+      return;
+    }
+  }
+  const ownerKey = toolSessionOwnerKey(req, remoteAddress);
   const requested = normalizeModelId(body.model);
   const model = resolveModel(requested, lastRequestedModelRef, config);
   const models = await getCachedCursorModels(config, modelCacheRef);
@@ -196,12 +522,40 @@ export async function handleResponses(
     decision.requestedWasDefault && config.defaultModel !== "default"
       ? config.defaultModel
       : model;
+  const modelCatalogName = models.find(
+    (item) => item.id === cursorModel,
+  )?.name;
+  const id = `resp_${randomUUID().replace(/-/g, "")}`;
+  const createdAt = Math.floor(Date.now() / 1000);
 
   const cleanMessages = sanitizeMessages(responsesInputToMessages(body));
-  const toolsText = toolsToSystemText(body.tools);
-  const messagesWithTools = toolsText
-    ? [{ role: "system", content: toolsText }, ...cleanMessages]
-    : cleanMessages;
+  const structuredToolStart =
+    config.useAcp &&
+    selectedTools.length > 0 &&
+    submittedToolOutputs.length === 0;
+  if (structuredToolStart && body.store === false) {
+    json(res, 400, {
+      error: {
+        message:
+          "store=false is incompatible with stateful ACP tool passthrough",
+        code: "invalid_store",
+        type: "invalid_request_error",
+      },
+    });
+    return;
+  }
+  const toolsText = structuredToolStart
+    ? undefined
+    : body.tool_choice === "none"
+      ? undefined
+      : toolsToSystemText(body.tools);
+  const messagesWithTools = [
+    ...(toolInstruction && structuredToolStart
+      ? [{ role: "system", content: toolInstruction }]
+      : []),
+    ...(toolsText ? [{ role: "system", content: toolsText }] : []),
+    ...cleanMessages,
+  ];
   const prompt = buildPromptFromMessages(messagesWithTools);
 
   const trafficMessages: TrafficMessage[] = cleanMessages.map((m: any) => ({
@@ -214,6 +568,102 @@ export async function handleResponses(
     trafficMessages,
     !!body.stream,
   );
+
+  if (config.useAcp && submittedToolOutputs.length > 0) {
+    const previousResponseId = body.previous_response_id;
+    const record =
+      typeof previousResponseId === "string"
+        ? ctx.toolSessions.findByResponseId(ownerKey, previousResponseId)
+        : undefined;
+    if (
+      !record ||
+      record.api !== "responses" ||
+      !submittedToolOutputs.every((output) =>
+        record.session.hasCall(output.callId),
+      )
+    ) {
+      json(res, 409, {
+        error: {
+          message:
+            "Response tool session is missing or expired; resend the original input",
+          code: "tool_session_expired",
+          type: "invalid_request_error",
+        },
+      });
+      return;
+    }
+    const configDir = record.configDir;
+    logAccountAssigned(configDir);
+    reportRequestStart(configDir);
+    const startedAt = Date.now();
+    const abortController = new AbortController();
+    abortOnClientDisconnect(res, abortController);
+    abortController.signal.addEventListener(
+      "abort",
+      () => void record.session.close(),
+      { once: true },
+    );
+    try {
+      const result = await writeStructuredResponseTurn({
+        res,
+        body,
+        stream: !!body.stream,
+        id,
+        createdAt,
+        model: displayModel,
+        previousResponseId,
+        promptLength: prompt.length,
+        run: async (listener) => {
+          const turn = await ctx.toolSessions.resume(
+            record,
+            submittedToolOutputs,
+            listener,
+          );
+          if (turn.status === "tool_calls") {
+            ctx.toolSessions.aliasResponse(record, id);
+          }
+          return turn;
+        },
+      });
+      reportRequestSuccess(configDir, Date.now() - startedAt);
+      logTrafficResponse(
+        config.verbose,
+        model ?? cursorModel,
+        result.text,
+        !!body.stream,
+      );
+    } catch (error) {
+      reportRequestError(configDir, Date.now() - startedAt);
+      if (!res.headersSent) {
+        json(res, error instanceof ToolSessionError ? error.status : 500, {
+          error: {
+            message: error instanceof Error ? error.message : String(error),
+            code:
+              error instanceof ToolSessionError
+                ? error.code
+                : "tool_session_error",
+          },
+        });
+      } else if (!res.writableEnded) {
+        writeResponseEvent(res, "response.failed", {
+          response: {
+            id,
+            object: "response",
+            status: "failed",
+            error: {
+              message: error instanceof Error ? error.message : String(error),
+              code: "tool_session_error",
+            },
+          },
+        });
+        res.end();
+      }
+    } finally {
+      reportRequestEnd(configDir);
+      logAccountStats(config.verbose, getAccountStats());
+    }
+    return;
+  }
 
   let mode: CursorExecutionMode;
   try {
@@ -289,14 +739,113 @@ export async function handleResponses(
   const cmdArgs =
     config.promptViaStdin || config.useAcp ? fixedArgs : fit.args;
 
-  const id = `resp_${randomUUID().replace(/-/g, "")}`;
   const itemId = `msg_${randomUUID().replace(/-/g, "")}`;
-  const createdAt = Math.floor(Date.now() / 1000);
   const promptForAgent =
     config.promptViaStdin || config.useAcp ? agentPrompt : undefined;
   const truncatedHeaders = fit.truncated
     ? { "X-Cursor-Proxy-Prompt-Truncated": "true" }
     : undefined;
+
+  if (structuredToolStart) {
+    const configDir = getNextAccountConfigDir();
+    logAccountAssigned(configDir);
+    reportRequestStart(configDir);
+    const startedAt = Date.now();
+    const abortController = new AbortController();
+    abortOnClientDisconnect(res, abortController);
+    let record: ToolSessionRecord | undefined;
+    try {
+      const session = await startAgentToolSession({
+        config,
+        workspaceDir,
+        effectiveChatOnly,
+        cmdArgs,
+        prompt: agentPrompt,
+        tools: selectedTools,
+        tempDir,
+        configDir,
+        signal: abortController.signal,
+        modelDisplayName: modelCatalogName,
+        requireToolCall,
+        maxParallelToolCalls,
+      });
+      record = ctx.toolSessions.createRecord({
+        api: "responses",
+        ownerKey,
+        model: displayModel ?? cursorModel,
+        configDir,
+        session,
+      });
+      abortController.signal.addEventListener(
+        "abort",
+        () => void session.close(),
+        { once: true },
+      );
+      const result = await writeStructuredResponseTurn({
+        res,
+        body,
+        stream: !!body.stream,
+        id,
+        createdAt,
+        model: displayModel,
+        previousResponseId: body.previous_response_id,
+        promptLength: agentPrompt.length,
+        run: async (listener) => {
+          const turn = await ctx.toolSessions.collect(record!, listener);
+          if (turn.status === "tool_calls") {
+            ctx.toolSessions.aliasResponse(record!, id);
+          }
+          return turn;
+        },
+      });
+      reportRequestSuccess(configDir, Date.now() - startedAt);
+      if (
+        result.status === "completed" &&
+        result.stderr &&
+        isRateLimited(result.stderr)
+      ) {
+        reportRateLimit(configDir, 60_000);
+      }
+      logTrafficResponse(
+        config.verbose,
+        model ?? cursorModel,
+        result.text,
+        !!body.stream,
+      );
+    } catch (error) {
+      if (record) {
+        ctx.toolSessions.remove(record);
+        await record.session.close().catch(() => undefined);
+      }
+      reportRequestError(configDir, Date.now() - startedAt);
+      if (!res.headersSent) {
+        json(res, 500, {
+          error: {
+            message: error instanceof Error ? error.message : String(error),
+            code: "tool_session_error",
+            type: "api_error",
+          },
+        });
+      } else if (!res.writableEnded) {
+        writeResponseEvent(res, "response.failed", {
+          response: {
+            id,
+            object: "response",
+            status: "failed",
+            error: {
+              message: error instanceof Error ? error.message : String(error),
+              code: "tool_session_error",
+            },
+          },
+        });
+        res.end();
+      }
+    } finally {
+      reportRequestEnd(configDir);
+      logAccountStats(config.verbose, getAccountStats());
+    }
+    return;
+  }
 
   if (body.stream) {
     const configDir = getNextAccountConfigDir();
@@ -402,6 +951,7 @@ export async function handleResponses(
         promptForAgent,
         configDir,
         abortController.signal,
+        modelCatalogName,
       )
         .then(({ code, stderr: stderrOut }) => {
           const latencyMs = Date.now() - streamStart;
@@ -479,6 +1029,7 @@ export async function handleResponses(
       promptForAgent,
       configDir,
       abortController.signal,
+      modelCatalogName,
     )
       .then(({ code, stderr: stderrOut }) => {
         const latencyMs = Date.now() - streamStart;
@@ -537,6 +1088,7 @@ export async function handleResponses(
     promptForAgent,
     configDir,
     abortController.signal,
+    modelCatalogName,
   );
   const syncLatency = Date.now() - syncStart;
   reportRequestEnd(configDir);

--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -6,6 +6,7 @@ export type OpenAiChatCompletionRequest = {
   stream?: boolean;
   tools?: any[];
   tool_choice?: any;
+  parallel_tool_calls?: boolean;
   functions?: any[];
   function_call?: any;
 };

--- a/src/lib/request-listener.ts
+++ b/src/lib/request-listener.ts
@@ -15,13 +15,21 @@ import {
 } from "./admin-dashboard.js";
 import { extractBearerToken, json, readBody } from "./http.js";
 import { appendSessionLine, logIncoming } from "./request-log.js";
+import type { ToolSessionRegistry } from "./tool-session-registry.js";
 
 export type BridgeServerOptions = {
   version: string;
   config: BridgeConfig;
 };
 
-export function createRequestListener(opts: BridgeServerOptions) {
+export type BridgeRequestRuntime = {
+  toolSessions: ToolSessionRegistry;
+};
+
+export function createRequestListener(
+  opts: BridgeServerOptions,
+  runtime: BridgeRequestRuntime,
+) {
   const { config } = opts;
   const modelCacheRef: ModelCacheRef = { current: undefined };
   const lastRequestedModelRef: { current?: string } = {};
@@ -97,7 +105,12 @@ export function createRequestListener(opts: BridgeServerOptions) {
         await handleChatCompletions(
           req,
           res,
-          { config, lastRequestedModelRef, modelCacheRef },
+          {
+            config,
+            lastRequestedModelRef,
+            modelCacheRef,
+            toolSessions: runtime.toolSessions,
+          },
           raw,
           method,
           pathname,
@@ -111,7 +124,12 @@ export function createRequestListener(opts: BridgeServerOptions) {
         await handleResponses(
           req,
           res,
-          { config, lastRequestedModelRef, modelCacheRef },
+          {
+            config,
+            lastRequestedModelRef,
+            modelCacheRef,
+            toolSessions: runtime.toolSessions,
+          },
           raw,
           method,
           pathname,
@@ -125,7 +143,12 @@ export function createRequestListener(opts: BridgeServerOptions) {
         await handleAnthropicMessages(
           req,
           res,
-          { config, lastRequestedModelRef, modelCacheRef },
+          {
+            config,
+            lastRequestedModelRef,
+            modelCacheRef,
+            toolSessions: runtime.toolSessions,
+          },
           raw,
           method,
           pathname,

--- a/src/lib/server.ts
+++ b/src/lib/server.ts
@@ -6,6 +6,7 @@ import type { BridgeConfig } from "./config.js";
 import { createRequestListener } from "./request-listener.js";
 import { initAccountPool } from "./account-pool.js";
 import { killAllChildProcesses } from "./process.js";
+import { ToolSessionRegistry } from "./tool-session-registry.js";
 
 function acpLauncherLabel(acpArgs: string[]): string {
   const first = acpArgs[0];
@@ -104,7 +105,8 @@ function startSingleServer(
 ): http.Server | https.Server {
   const { config } = opts;
 
-  const requestListener = createRequestListener(opts);
+  const toolSessions = new ToolSessionRegistry();
+  const requestListener = createRequestListener(opts, { toolSessions });
 
   const useTls = Boolean(config.tlsCertPath && config.tlsKeyPath);
   let server: http.Server | https.Server;
@@ -126,6 +128,9 @@ function startSingleServer(
       console.error(`\u274c Server error:`, err.message);
     }
     process.exit(1);
+  });
+  server.once("close", () => {
+    void toolSessions.closeAll();
   });
 
   server.listen(config.port, config.host, () => {

--- a/src/lib/tool-api-integration.test.ts
+++ b/src/lib/tool-api-integration.test.ts
@@ -1,0 +1,461 @@
+import * as http from "node:http";
+import { join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import type { BridgeConfig } from "./config.js";
+import { startBridgeServer } from "./server.js";
+
+vi.mock("./cursor-cli.js", () => ({
+  listCursorCliModels: vi.fn().mockResolvedValue([
+    { id: "gpt-4", name: "gpt-4" },
+  ]),
+}));
+
+const fakeServerPath = join(
+  process.cwd(),
+  "src",
+  "lib",
+  "__tests__",
+  "fake-acp-server.mjs",
+);
+const servers: http.Server[] = [];
+
+function config(scenario = "tool_call"): BridgeConfig {
+  return {
+    agentBin: "agent",
+    acpCommand: process.execPath,
+    acpArgs: [fakeServerPath],
+    acpEnv: { FAKE_ACP_SCENARIO: scenario },
+    host: "127.0.0.1",
+    port: 0,
+    defaultModel: "gpt-4",
+    mode: "ask",
+    force: false,
+    approveMcps: false,
+    strictModel: true,
+    workspace: process.cwd(),
+    timeoutMs: 10_000,
+    sessionsLogPath: "/tmp/cursor-api-proxy-tool-test.log",
+    chatOnlyWorkspace: true,
+    chatOnlyWorkspaceExplicit: false,
+    verbose: false,
+    maxMode: false,
+    promptViaStdin: false,
+    useAcp: true,
+    acpSkipAuthenticate: true,
+    acpRawDebug: false,
+    configDirs: [],
+    multiPort: false,
+    winCmdlineMax: 30_000,
+    contextPreamble: false,
+    bridgePackageVersion: "0.0.0-test",
+  };
+}
+
+async function start(scenario = "tool_call") {
+  const [server] = startBridgeServer({
+    version: "test",
+    config: config(scenario),
+  });
+  servers.push(server as http.Server);
+  await new Promise<void>((resolve) => server.once("listening", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("No port");
+  return `http://127.0.0.1:${address.port}`;
+}
+
+async function post(
+  base: string,
+  path: string,
+  body: unknown,
+  headers: Record<string, string> = {},
+) {
+  const response = await fetch(`${base}${path}`, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+  return {
+    status: response.status,
+    text: await response.text(),
+  };
+}
+
+function sseData(text: string): any[] {
+  return text
+    .split(/\r?\n/)
+    .filter((line) => line.startsWith("data: ") && line !== "data: [DONE]")
+    .map((line) => JSON.parse(line.slice(6)));
+}
+
+afterEach(async () => {
+  await Promise.all(
+    servers.splice(0).map(
+      (server) =>
+        new Promise<void>((resolve) => server.close(() => resolve())),
+    ),
+  );
+});
+
+describe.each([false, true])("ACP tool APIs stream=%s", (stream) => {
+  it("round-trips Chat Completions tool calls", async () => {
+    const base = await start();
+    const initial = await post(base, "/v1/chat/completions", {
+      model: "gpt-4",
+      stream,
+      messages: [{ role: "user", content: "Weather?" }],
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "weather",
+            description: "Get weather",
+            parameters: {
+              type: "object",
+              properties: { city: { type: "string" } },
+            },
+          },
+        },
+      ],
+    });
+    expect(initial.status).toBe(200);
+    const chunks = stream ? sseData(initial.text) : [];
+    const payload = stream ? undefined : JSON.parse(initial.text);
+    const call = stream
+      ? chunks
+          .flatMap((chunk) => chunk.choices ?? [])
+          .flatMap((choice: any) => choice.delta?.tool_calls ?? [])[0]
+      : payload.choices[0].message.tool_calls[0];
+    expect(call.function.name).toBe("weather");
+    expect(
+      stream
+        ? chunks.some(
+            (chunk) => chunk.choices?.[0]?.finish_reason === "tool_calls",
+          )
+        : payload.choices[0].finish_reason === "tool_calls",
+    ).toBe(true);
+
+    const follow = await post(base, "/v1/chat/completions", {
+      model: "gpt-4",
+      stream: false,
+      messages: [
+        { role: "user", content: "Weather?" },
+        {
+          role: "assistant",
+          content: null,
+          tool_calls: [call],
+        },
+        {
+          role: "tool",
+          tool_call_id: call.id,
+          content: "sunny",
+        },
+      ],
+    });
+    expect(follow.status).toBe(200);
+    expect(JSON.parse(follow.text).choices[0].message.content).toContain(
+      "Tool result: sunny",
+    );
+  });
+
+  it("round-trips Responses function calls", async () => {
+    const base = await start();
+    const initial = await post(base, "/v1/responses", {
+      model: "gpt-4",
+      stream,
+      input: "Weather?",
+      tools: [
+        {
+          type: "function",
+          name: "weather",
+          description: "Get weather",
+          parameters: {
+            type: "object",
+            properties: { city: { type: "string" } },
+          },
+        },
+      ],
+    });
+    expect(initial.status).toBe(200);
+    const events = stream ? sseData(initial.text) : [];
+    const payload = stream
+      ? events.find((event) => event.type === "response.completed").response
+      : JSON.parse(initial.text);
+    const call = payload.output.find(
+      (item: any) => item.type === "function_call",
+    );
+    expect(call.name).toBe("weather");
+
+    const follow = await post(base, "/v1/responses", {
+      model: "gpt-4",
+      stream: false,
+      previous_response_id: payload.id,
+      input: [
+        {
+          type: "function_call_output",
+          call_id: call.call_id,
+          output: "sunny",
+        },
+      ],
+    });
+    expect(follow.status).toBe(200);
+    expect(JSON.parse(follow.text).output_text).toContain("Tool result: sunny");
+  });
+
+  it("round-trips Anthropic tool_use blocks", async () => {
+    const base = await start();
+    const initial = await post(base, "/v1/messages", {
+      model: "gpt-4",
+      max_tokens: 256,
+      stream,
+      messages: [{ role: "user", content: "Weather?" }],
+      tools: [
+        {
+          name: "weather",
+          description: "Get weather",
+          input_schema: {
+            type: "object",
+            properties: { city: { type: "string" } },
+          },
+        },
+      ],
+    });
+    expect(initial.status).toBe(200);
+    const events = stream ? sseData(initial.text) : [];
+    const payload = stream ? undefined : JSON.parse(initial.text);
+    const call = stream
+      ? events.find(
+          (event) =>
+            event.type === "content_block_start" &&
+            event.content_block?.type === "tool_use",
+        ).content_block
+      : payload.content.find((block: any) => block.type === "tool_use");
+    expect(call.name).toBe("weather");
+    if (stream) {
+      expect(
+        events.some(
+          (event) =>
+            event.type === "content_block_delta" &&
+            event.delta?.type === "input_json_delta",
+        ),
+      ).toBe(true);
+    } else {
+      expect(payload.stop_reason).toBe("tool_use");
+    }
+
+    const follow = await post(base, "/v1/messages", {
+      model: "gpt-4",
+      max_tokens: 256,
+      stream: false,
+      messages: [
+        { role: "user", content: "Weather?" },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_use",
+              id: call.id,
+              name: call.name,
+              input: call.input,
+            },
+          ],
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: call.id,
+              content: "sunny",
+            },
+          ],
+        },
+      ],
+    });
+    expect(follow.status).toBe(200);
+    expect(JSON.parse(follow.text).content[0].text).toContain(
+      "Tool result: sunny",
+    );
+  });
+});
+
+describe("ACP tool session errors", () => {
+  it("returns conflict for unknown tool call ids", async () => {
+    const base = await start();
+    const response = await post(base, "/v1/chat/completions", {
+      model: "gpt-4",
+      messages: [
+        { role: "tool", tool_call_id: "call_missing", content: "result" },
+      ],
+    });
+    expect(response.status).toBe(409);
+    expect(JSON.parse(response.text).error.code).toBe("tool_session_expired");
+  });
+
+  it("supports partial parallel results", async () => {
+    const base = await start("tool_parallel");
+    const initial = await post(base, "/v1/chat/completions", {
+      model: "gpt-4",
+      messages: [{ role: "user", content: "Both?" }],
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "weather",
+            parameters: { type: "object", properties: {} },
+          },
+        },
+        {
+          type: "function",
+          function: {
+            name: "time",
+            parameters: { type: "object", properties: {} },
+          },
+        },
+      ],
+    });
+    const calls = JSON.parse(initial.text).choices[0].message.tool_calls;
+    expect(calls).toHaveLength(2);
+
+    const partial = await post(base, "/v1/chat/completions", {
+      model: "gpt-4",
+      messages: [
+        {
+          role: "tool",
+          tool_call_id: calls[0].id,
+          content: "weather-result",
+        },
+      ],
+    });
+    const remaining = JSON.parse(partial.text).choices[0].message.tool_calls;
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].id).toBe(calls[1].id);
+
+    const final = await post(base, "/v1/chat/completions", {
+      model: "gpt-4",
+      messages: [
+        {
+          role: "tool",
+          tool_call_id: calls[1].id,
+          content: "time-result",
+        },
+      ],
+    });
+    expect(JSON.parse(final.text).choices[0].message.content).toContain(
+      "weather-result, time-result",
+    );
+  });
+
+  it("binds pending calls to the initiating API owner", async () => {
+    const base = await start();
+    const initial = await post(
+      base,
+      "/v1/chat/completions",
+      {
+        model: "gpt-4",
+        messages: [{ role: "user", content: "Weather?" }],
+        tools: [
+          {
+            type: "function",
+            function: {
+              name: "weather",
+              parameters: { type: "object", properties: {} },
+            },
+          },
+        ],
+      },
+      { authorization: "Bearer owner-a" },
+    );
+    const call = JSON.parse(initial.text).choices[0].message.tool_calls[0];
+    const wrongOwner = await post(
+      base,
+      "/v1/chat/completions",
+      {
+        model: "gpt-4",
+        messages: [
+          {
+            role: "tool",
+            tool_call_id: call.id,
+            content: "stolen",
+          },
+        ],
+      },
+      { authorization: "Bearer owner-b" },
+    );
+    expect(wrongOwner.status).toBe(409);
+  });
+
+  it("serializes concurrent results for one parallel turn", async () => {
+    const base = await start("tool_parallel");
+    const initial = await post(base, "/v1/chat/completions", {
+      model: "gpt-4",
+      messages: [{ role: "user", content: "Both?" }],
+      tools: [
+        {
+          type: "function",
+          function: {
+            name: "weather",
+            parameters: { type: "object", properties: {} },
+          },
+        },
+        {
+          type: "function",
+          function: {
+            name: "time",
+            parameters: { type: "object", properties: {} },
+          },
+        },
+      ],
+    });
+    const calls = JSON.parse(initial.text).choices[0].message.tool_calls;
+    const replies = await Promise.all(
+      calls.map((call: any) =>
+        post(base, "/v1/chat/completions", {
+          model: "gpt-4",
+          messages: [
+            {
+              role: "tool",
+              tool_call_id: call.id,
+              content: `${call.function.name}-result`,
+            },
+          ],
+        }),
+      ),
+    );
+    expect(replies.every((reply) => reply.status === 200)).toBe(true);
+    const payloads = replies.map((reply) => JSON.parse(reply.text));
+    expect(
+      payloads.some((payload) =>
+        payload.choices[0].message.content?.includes(
+          "weather-result, time-result",
+        ),
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects unsupported tool types and store=false tool loops", async () => {
+    const base = await start();
+    const unsupported = await post(base, "/v1/chat/completions", {
+      model: "gpt-4",
+      messages: [{ role: "user", content: "Search" }],
+      tools: [{ type: "web_search" }],
+    });
+    expect(unsupported.status).toBe(400);
+    expect(JSON.parse(unsupported.text).error.code).toBe("invalid_tools");
+
+    const noStore = await post(base, "/v1/responses", {
+      model: "gpt-4",
+      input: "Weather?",
+      store: false,
+      tools: [
+        {
+          type: "function",
+          name: "weather",
+          parameters: { type: "object", properties: {} },
+        },
+      ],
+    });
+    expect(noStore.status).toBe(400);
+    expect(JSON.parse(noStore.text).error.code).toBe("invalid_store");
+  });
+});

--- a/src/lib/tool-session-registry.ts
+++ b/src/lib/tool-session-registry.ts
@@ -1,0 +1,218 @@
+import { createHash, randomUUID } from "node:crypto";
+import type * as http from "node:http";
+
+import type {
+  AcpToolSession,
+  ToolTurnEvent,
+  ToolTurnResult,
+} from "./acp-tool-session.js";
+import { extractBearerToken } from "./http.js";
+import type { ClientToolOutput } from "./tool-types.js";
+
+export type ToolApi = "chat" | "responses" | "anthropic";
+const MAX_GLOBAL_TOOL_SESSIONS = 64;
+const MAX_OWNER_TOOL_SESSIONS = 8;
+
+class Mutex {
+  #tail = Promise.resolve();
+
+  async run<T>(operation: () => Promise<T>): Promise<T> {
+    const prior = this.#tail;
+    let release!: () => void;
+    this.#tail = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await prior;
+    try {
+      return await operation();
+    } finally {
+      release();
+    }
+  }
+}
+
+export type ToolSessionRecord = {
+  id: string;
+  api: ToolApi;
+  ownerKey: string;
+  model: string;
+  configDir?: string;
+  session: AcpToolSession;
+  mutex: Mutex;
+  responseIds: Set<string>;
+  createdAt: number;
+  lastUsed: number;
+};
+
+export class ToolSessionError extends Error {
+  constructor(
+    message: string,
+    readonly status = 409,
+    readonly code = "tool_session_error",
+  ) {
+    super(message);
+  }
+}
+
+export function toolSessionOwnerKey(
+  req: http.IncomingMessage,
+  remoteAddress: string,
+): string {
+  const bearer = extractBearerToken(req);
+  return createHash("sha256")
+    .update(bearer ? `bearer:${bearer}` : `remote:${remoteAddress}`)
+    .digest("hex");
+}
+
+export class ToolSessionRegistry {
+  readonly #records = new Set<ToolSessionRecord>();
+  readonly #byResponseId = new Map<string, ToolSessionRecord>();
+  #closePromise?: Promise<void>;
+
+  createRecord(opts: {
+    api: ToolApi;
+    ownerKey: string;
+    model: string;
+    configDir?: string;
+    session: AcpToolSession;
+  }): ToolSessionRecord {
+    this.#sweep();
+    const ownerCount = [...this.#records].filter(
+      (record) => record.ownerKey === opts.ownerKey,
+    ).length;
+    if (
+      this.#records.size >= MAX_GLOBAL_TOOL_SESSIONS ||
+      ownerCount >= MAX_OWNER_TOOL_SESSIONS
+    ) {
+      void opts.session.close();
+      throw new ToolSessionError(
+        "Too many parked tool sessions; finish or cancel an existing turn",
+        429,
+        "tool_session_limit",
+      );
+    }
+    const record: ToolSessionRecord = {
+      id: `toolsess_${randomUUID().replace(/-/g, "")}`,
+      api: opts.api,
+      ownerKey: opts.ownerKey,
+      model: opts.model,
+      configDir: opts.configDir,
+      session: opts.session,
+      mutex: new Mutex(),
+      responseIds: new Set(),
+      createdAt: Date.now(),
+      lastUsed: Date.now(),
+    };
+    this.#records.add(record);
+    return record;
+  }
+
+  aliasResponse(record: ToolSessionRecord, responseId: string): void {
+    record.responseIds.add(responseId);
+    this.#byResponseId.set(responseId, record);
+  }
+
+  findByCallIds(
+    api: ToolApi,
+    ownerKey: string,
+    callIds: readonly string[],
+  ): ToolSessionRecord | undefined {
+    this.#sweep();
+    if (callIds.length === 0) return undefined;
+    return [...this.#records].find(
+      (record) =>
+        record.api === api &&
+        record.ownerKey === ownerKey &&
+        !record.session.closed &&
+        callIds.every((callId) => record.session.hasCall(callId)),
+    );
+  }
+
+  findByResponseId(
+    ownerKey: string,
+    responseId: string,
+  ): ToolSessionRecord | undefined {
+    this.#sweep();
+    const record = this.#byResponseId.get(responseId);
+    return record &&
+      record.ownerKey === ownerKey &&
+      !record.session.closed
+      ? record
+      : undefined;
+  }
+
+  async collect(
+    record: ToolSessionRecord,
+    listener?: (event: ToolTurnEvent) => void,
+  ): Promise<ToolTurnResult> {
+    return record.mutex.run(async () => {
+      record.lastUsed = Date.now();
+      try {
+        return await record.session.collect(listener);
+      } finally {
+        if (record.session.closed || record.session.terminal) {
+          this.remove(record);
+        }
+      }
+    });
+  }
+
+  async resume(
+    record: ToolSessionRecord,
+    outputs: readonly ClientToolOutput[],
+    listener?: (event: ToolTurnEvent) => void,
+  ): Promise<ToolTurnResult> {
+    return record.mutex.run(async () => {
+      if (
+        record.session.closed ||
+        outputs.some((output) => !record.session.hasCall(output.callId))
+      ) {
+        throw new ToolSessionError(
+          "Tool call is already resolved, unknown, or expired",
+          409,
+          "tool_session_expired",
+        );
+      }
+      record.lastUsed = Date.now();
+      try {
+        return await record.session.resume(outputs, listener);
+      } finally {
+        if (record.session.closed || record.session.terminal) {
+          this.remove(record);
+        }
+      }
+    });
+  }
+
+  remove(record: ToolSessionRecord): void {
+    this.#records.delete(record);
+    for (const responseId of record.responseIds) {
+      if (this.#byResponseId.get(responseId) === record) {
+        this.#byResponseId.delete(responseId);
+      }
+    }
+  }
+
+  async closeAll(): Promise<void> {
+    if (!this.#closePromise) {
+      const records = [...this.#records];
+      this.#records.clear();
+      this.#byResponseId.clear();
+      this.#closePromise = Promise.all(
+        records.map((record) => record.session.close().catch(() => undefined)),
+      ).then(() => undefined);
+    }
+    await this.#closePromise;
+  }
+
+  get size(): number {
+    this.#sweep();
+    return this.#records.size;
+  }
+
+  #sweep(): void {
+    for (const record of this.#records) {
+      if (record.session.closed) this.remove(record);
+    }
+  }
+}

--- a/src/lib/tool-types.test.ts
+++ b/src/lib/tool-types.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  anthropicToolOutputs,
+  chatToolOutputs,
+  parseAnthropicFunctionTools,
+  parseOpenAiFunctionTools,
+  resolveToolChoice,
+  responsesToolOutputs,
+} from "./tool-types.js";
+
+describe("tool normalization", () => {
+  it("accepts Chat, Responses, legacy, and Anthropic function schemas", () => {
+    expect(
+      parseOpenAiFunctionTools([
+        {
+          type: "function",
+          function: {
+            name: "chat",
+            parameters: { type: "object", properties: { x: {} } },
+          },
+        },
+        {
+          type: "function",
+          name: "response",
+          parameters: { type: "object", properties: { y: {} } },
+        },
+      ]),
+    ).toEqual([
+      {
+        name: "chat",
+        description: undefined,
+        inputSchema: { type: "object", properties: { x: {} } },
+      },
+      {
+        name: "response",
+        description: undefined,
+        inputSchema: { type: "object", properties: { y: {} } },
+      },
+    ]);
+    expect(
+      parseOpenAiFunctionTools(undefined, [
+        {
+          name: "legacy",
+          parameters: { type: "object", properties: {} },
+        },
+      ])[0].name,
+    ).toBe("legacy");
+    expect(
+      parseAnthropicFunctionTools([
+        {
+          name: "anthropic",
+          input_schema: { type: "object", properties: {} },
+        },
+      ])[0].inputSchema,
+    ).toEqual({ type: "object", properties: {} });
+  });
+
+  it("rejects unsupported and duplicate tools", () => {
+    expect(() =>
+      parseOpenAiFunctionTools([{ type: "web_search" }]),
+    ).toThrow(/Unsupported tool type/);
+    expect(() =>
+      parseOpenAiFunctionTools([
+        { type: "function", name: "same" },
+        { type: "function", function: { name: "same" } },
+      ]),
+    ).toThrow(/Duplicate/);
+  });
+
+  it("implements none, required, named, and no-parallel choices", () => {
+    const tools = [
+      {
+        name: "one",
+        inputSchema: { type: "object", properties: {} },
+      },
+      {
+        name: "two",
+        inputSchema: { type: "object", properties: {} },
+      },
+    ];
+    expect(resolveToolChoice(tools, "none").tools).toEqual([]);
+    expect(resolveToolChoice(tools, "required").instruction).toMatch(/must/);
+    expect(
+      resolveToolChoice(tools, {
+        type: "function",
+        function: { name: "two" },
+      }).tools.map((tool) => tool.name),
+    ).toEqual(["two"]);
+    expect(
+      resolveToolChoice(tools, "auto", { parallelToolCalls: false })
+        .instruction,
+    ).toMatch(/at most one/i);
+    expect(() =>
+      resolveToolChoice(tools, { type: "tool", name: "missing" }),
+    ).toThrow(/Unknown/);
+  });
+});
+
+describe("tool output correlation", () => {
+  it("reads Chat tool_call_id", () => {
+    expect(
+      chatToolOutputs([
+        { role: "user", content: "x" },
+        { role: "tool", tool_call_id: "call_1", content: { ok: true } },
+      ]),
+    ).toEqual([{ callId: "call_1", output: '{"ok":true}' }]);
+  });
+
+  it("reads Responses function_call_output", () => {
+    expect(
+      responsesToolOutputs([
+        {
+          type: "function_call_output",
+          call_id: "call_2",
+          output: "done",
+        },
+      ]),
+    ).toEqual([{ callId: "call_2", output: "done" }]);
+  });
+
+  it("reads Anthropic tool_result and error state", () => {
+    expect(
+      anthropicToolOutputs([
+        {
+          role: "user",
+          content: [
+            {
+              type: "tool_result",
+              tool_use_id: "call_3",
+              content: [{ type: "text", text: "failed" }],
+              is_error: true,
+            },
+          ],
+        },
+      ]),
+    ).toEqual([
+      { callId: "call_3", output: "failed", isError: true },
+    ]);
+  });
+});

--- a/src/lib/tool-types.ts
+++ b/src/lib/tool-types.ts
@@ -1,0 +1,253 @@
+export type ClientToolDefinition = {
+  name: string;
+  description?: string;
+  inputSchema: Record<string, unknown>;
+};
+
+export type ClientToolOutput = {
+  callId: string;
+  output: string;
+  isError?: boolean;
+};
+
+export type PendingClientToolCall = {
+  callId: string;
+  itemId: string;
+  name: string;
+  arguments: string;
+};
+
+export type ResolvedToolChoice = {
+  tools: ClientToolDefinition[];
+  instruction?: string;
+  required: boolean;
+  maxParallelToolCalls?: number;
+};
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return undefined;
+  }
+  return value as Record<string, unknown>;
+}
+
+function schemaOrDefault(value: unknown): Record<string, unknown> {
+  return (
+    asRecord(value) ?? {
+      type: "object",
+      properties: {},
+    }
+  );
+}
+
+function pushUnique(
+  out: ClientToolDefinition[],
+  seen: Set<string>,
+  definition: ClientToolDefinition,
+): void {
+  if (!definition.name.trim()) {
+    throw new Error("Function tool is missing name");
+  }
+  if (seen.has(definition.name)) {
+    throw new Error(`Duplicate function tool name: ${definition.name}`);
+  }
+  seen.add(definition.name);
+  out.push(definition);
+}
+
+/**
+ * Parse OpenAI Chat Completions (`function` wrapper), Responses (flat
+ * function), and legacy Chat `functions` definitions.
+ */
+export function parseOpenAiFunctionTools(
+  tools?: readonly unknown[],
+  functions?: readonly unknown[],
+): ClientToolDefinition[] {
+  const out: ClientToolDefinition[] = [];
+  const seen = new Set<string>();
+
+  for (const value of tools ?? []) {
+    const tool = asRecord(value);
+    if (!tool) throw new Error("Invalid tool definition");
+    if (tool.type !== "function") {
+      throw new Error(
+        `Unsupported tool type: ${
+          typeof tool.type === "string" ? tool.type : "unknown"
+        }`,
+      );
+    }
+    const wrapped = asRecord(tool.function);
+    const fn = wrapped ?? tool;
+    if (typeof fn.name !== "string") {
+      throw new Error("Function tool is missing name");
+    }
+    pushUnique(out, seen, {
+      name: fn.name,
+      description:
+        typeof fn.description === "string" ? fn.description : undefined,
+      inputSchema: schemaOrDefault(fn.parameters),
+    });
+  }
+
+  for (const value of functions ?? []) {
+    const fn = asRecord(value);
+    if (!fn || typeof fn.name !== "string") {
+      throw new Error("Function is missing name");
+    }
+    pushUnique(out, seen, {
+      name: fn.name,
+      description:
+        typeof fn.description === "string" ? fn.description : undefined,
+      inputSchema: schemaOrDefault(fn.parameters),
+    });
+  }
+
+  return out;
+}
+
+export function parseAnthropicFunctionTools(
+  tools?: readonly unknown[],
+): ClientToolDefinition[] {
+  const out: ClientToolDefinition[] = [];
+  const seen = new Set<string>();
+  for (const value of tools ?? []) {
+    const tool = asRecord(value);
+    if (!tool || typeof tool.name !== "string") {
+      throw new Error("Anthropic tool is missing name");
+    }
+    pushUnique(out, seen, {
+      name: tool.name,
+      description:
+        typeof tool.description === "string" ? tool.description : undefined,
+      inputSchema: schemaOrDefault(tool.input_schema),
+    });
+  }
+  return out;
+}
+
+function namedChoice(choice: unknown): string | undefined {
+  const rec = asRecord(choice);
+  if (!rec) return undefined;
+  if (typeof rec.name === "string") return rec.name;
+  const fn = asRecord(rec.function);
+  if (fn && typeof fn.name === "string") return fn.name;
+  return undefined;
+}
+
+export function resolveToolChoice(
+  tools: readonly ClientToolDefinition[],
+  choice: unknown,
+  opts: { parallelToolCalls?: boolean; anthropic?: boolean } = {},
+): ResolvedToolChoice {
+  if (choice === "none" || asRecord(choice)?.type === "none") {
+    return { tools: [], required: false };
+  }
+
+  const required =
+    choice === "required" ||
+    choice === "any" ||
+    asRecord(choice)?.type === "any";
+  const selected = namedChoice(choice);
+  let resolved = [...tools];
+  let instruction: string | undefined;
+
+  if (selected) {
+    const tool = tools.find((item) => item.name === selected);
+    if (!tool) throw new Error(`Unknown tool_choice function: ${selected}`);
+    resolved = [tool];
+    instruction = `You must call the ${selected} tool.`;
+  } else if (required) {
+    instruction = "You must call at least one available tool.";
+  }
+
+  if (opts.parallelToolCalls === false && resolved.length > 0) {
+    instruction = [instruction, "Call at most one tool at a time."]
+      .filter(Boolean)
+      .join(" ");
+  }
+  return {
+    tools: resolved,
+    required: required || selected !== undefined,
+    ...(opts.parallelToolCalls === false ? { maxParallelToolCalls: 1 } : {}),
+    ...(instruction ? { instruction } : {}),
+  };
+}
+
+function stringifyOutput(value: unknown): string {
+  if (value == null) return "";
+  if (typeof value === "string") return value;
+  if (Array.isArray(value)) {
+    const text = value
+      .map((part) => {
+        if (typeof part === "string") return part;
+        const rec = asRecord(part);
+        return rec?.type === "text" && typeof rec.text === "string"
+          ? rec.text
+          : "";
+      })
+      .filter(Boolean)
+      .join("\n");
+    if (text) return text;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+export function chatToolOutputs(
+  messages: readonly unknown[],
+): ClientToolOutput[] {
+  const outputs: ClientToolOutput[] = [];
+  for (let i = messages.length - 1; i >= 0; i -= 1) {
+    const message = asRecord(messages[i]);
+    if (!message || message.role !== "tool") break;
+    if (typeof message.tool_call_id !== "string" || !message.tool_call_id) {
+      throw new Error("Tool message is missing tool_call_id");
+    }
+    outputs.unshift({
+      callId: message.tool_call_id,
+      output: stringifyOutput(message.content),
+    });
+  }
+  return outputs;
+}
+
+export function responsesToolOutputs(input: unknown): ClientToolOutput[] {
+  if (!Array.isArray(input)) return [];
+  const outputs: ClientToolOutput[] = [];
+  for (const value of input) {
+    const item = asRecord(value);
+    if (!item || item.type !== "function_call_output") continue;
+    if (typeof item.call_id !== "string" || !item.call_id) {
+      throw new Error("function_call_output is missing call_id");
+    }
+    outputs.push({
+      callId: item.call_id,
+      output: stringifyOutput(item.output),
+    });
+  }
+  return outputs;
+}
+
+export function anthropicToolOutputs(
+  messages: readonly unknown[],
+): ClientToolOutput[] {
+  const last = asRecord(messages[messages.length - 1]);
+  if (!last || last.role !== "user" || !Array.isArray(last.content)) return [];
+  const outputs: ClientToolOutput[] = [];
+  for (const value of last.content) {
+    const block = asRecord(value);
+    if (!block || block.type !== "tool_result") continue;
+    if (typeof block.tool_use_id !== "string" || !block.tool_use_id) {
+      throw new Error("tool_result is missing tool_use_id");
+    }
+    outputs.push({
+      callId: block.tool_use_id,
+      output: stringifyOutput(block.content),
+      isError: block.is_error === true,
+    });
+  }
+  return outputs;
+}


### PR DESCRIPTION
## Summary
- implement private loopback MCP bridge for ACP tool passthrough with parked `tools/call` lifecycle
- add native tool-call emit/resume for Chat Completions, Responses, and Anthropic (sync + stream)
- harden model mapping, binary detection, lifecycle cleanup, ownership, and coverage; bump version to 1.4.0

## Test plan
- [x] `npm run typecheck`
- [x] `npm test`
- [x] `npm run build`
- [x] live probe against installed `cursor-agent acp` for Chat/Responses/Anthropic tool roundtrip

Closes #36

Made with [Cursor](https://cursor.com)