### PR TITLE
fix(acp): projects mkdir, FORCE/TRUST argv, CLI→ACP model mapping

### DIFF
--- a/src/lib/acp-client.test.ts
+++ b/src/lib/acp-client.test.ts
@@ -79,6 +79,25 @@ describe("resolveAcpModelConfigValue", () => {
       ),
     ).toBe("gpt-5.6-sol[reasoning=high]");
   });
+
+  it("maps cursor-*-high CLI ids onto ACP catalog base modelId", () => {
+    expect(
+      resolveAcpModelConfigValue("cursor-grok-4.5-high", [
+        {
+          modelId: "grok-4.5[effort=high,fast=true]",
+          name: "Grok 4.5",
+        },
+      ]),
+    ).toBe("grok-4.5[effort=high,fast=true]");
+  });
+
+  it("maps auto to default[] when catalog has no auto row", () => {
+    expect(
+      resolveAcpModelConfigValue("auto", [
+        { modelId: "composer-2[fast=true]", name: "composer-2" },
+      ]),
+    ).toBe("default[]");
+  });
 });
 
 describe("runAcpSync", () => {

--- a/src/lib/acp-client.ts
+++ b/src/lib/acp-client.ts
@@ -239,10 +239,21 @@ export function resolveAcpModelConfigValue(
   aliases: readonly string[] = [],
 ): string {
   if (!availableModels?.length) return displayName;
+  const expand = (value: string): string[] => {
+    const v = value.trim().toLowerCase();
+    if (!v) return [];
+    const out = new Set([v]);
+    // CLI ids like cursor-grok-4.5-high / cursor-grok-4.5-high-fast → grok-4.5
+    const stripped = v
+      .replace(/^cursor-/, "")
+      .replace(/-(?:low|medium|high|xhigh|extra-high)(?:-fast)?$/, "")
+      .replace(/-fast$/, "");
+    out.add(stripped);
+    if (v === "auto") out.add("default[]");
+    return [...out];
+  };
   const candidates = new Set(
-    [displayName, ...aliases]
-      .map((value) => value.trim().toLowerCase())
-      .filter(Boolean),
+    [displayName, ...aliases].flatMap(expand).filter(Boolean),
   );
   const hit = availableModels.find((model) => {
     const modelId = model.modelId.trim().toLowerCase();
@@ -488,7 +499,8 @@ export function runAcpSync(
           if (
             resolvedModelId === "default[]" &&
             opts.strictModel &&
-            opts.model !== "default"
+            opts.model !== "default" &&
+            opts.model !== "auto"
           ) {
             throw new Error(
               `ACP model catalog has no match for ${JSON.stringify(opts.model)}`,
@@ -698,7 +710,8 @@ export function runAcpStream(
           if (
             resolvedModelId === "default[]" &&
             opts.strictModel &&
-            opts.model !== "default"
+            opts.model !== "default" &&
+            opts.model !== "auto"
           ) {
             throw new Error(
               `ACP model catalog has no match for ${JSON.stringify(opts.model)}`,

--- a/src/lib/agent-runner.test.ts
+++ b/src/lib/agent-runner.test.ts
@@ -90,4 +90,35 @@ describe("ACP requestTimeoutMs", () => {
       requestTimeoutMs: 123_456,
     });
   });
+
+  it("passes --force and --trust before acp when configured", async () => {
+    await runAgentSync(
+      config({ force: true }),
+      "/tmp/ws",
+      true,
+      ["--print", "--mode", "ask", "--model", "auto"],
+      undefined,
+      "hello",
+    );
+    const args = vi.mocked(runAcpSync).mock.calls[0][1] as string[];
+    const acpAt = args.indexOf("acp");
+    expect(acpAt).toBeGreaterThan(0);
+    expect(args.slice(0, acpAt)).toEqual(
+      expect.arrayContaining(["--force", "--trust", "--workspace", "/tmp/ws"]),
+    );
+  });
+
+  it("omits --force/--trust on ACP argv when not configured", async () => {
+    await runAgentSync(
+      config({ force: false }),
+      "/tmp/ws",
+      false,
+      ["--print", "--mode", "ask", "--model", "auto"],
+      undefined,
+      "hello",
+    );
+    const args = vi.mocked(runAcpSync).mock.calls[0][1] as string[];
+    expect(args).not.toContain("--force");
+    expect(args).not.toContain("--trust");
+  });
 });

--- a/src/lib/agent-runner.ts
+++ b/src/lib/agent-runner.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs";
+import * as path from "node:path";
 
 import { runAcpStream, runAcpSync } from "./acp-client.js";
 import { AcpToolSession } from "./acp-tool-session.js";
@@ -21,6 +22,31 @@ export type AgentRunResult = {
   stderr: string;
 };
 
+/** Match cursor-agent project id: drive + path, `\`/`/` → `-`, dots stripped. */
+function projectSlugFromPath(dir: string): string {
+  let s = path.resolve(dir);
+  if (process.platform === "win32") {
+    s = s.replace(/^([A-Za-z]):[\\/]/, "$1-");
+  } else if (s.startsWith("/")) {
+    s = s.slice(1);
+  }
+  return s.replace(/[\\/]+/g, "-").replace(/\./g, "");
+}
+
+/**
+ * cursor-agent writeFileSync's worker.log under CURSOR_CONFIG_DIR/projects/<slug>
+ * without mkdir. With chat-only + CURSOR_CONFIG_DIRS that is ~/.cursor/projects/<temp-slug>.
+ */
+function ensureAgentProjectDir(
+  workspaceDir: string,
+  configDir?: string,
+): void {
+  const cursorDir = configDir ?? path.join(workspaceDir, ".cursor");
+  fs.mkdirSync(path.join(cursorDir, "projects", projectSlugFromPath(workspaceDir)), {
+    recursive: true,
+  });
+}
+
 function acpArgsWithModel(acpArgs: string[], model: string): string[] {
   const i = acpArgs.indexOf("acp");
   if (i === -1) return acpArgs;
@@ -39,6 +65,14 @@ function acpArgsWithWorkspace(acpArgs: string[], workspaceDir: string): string[]
   const i = acpArgs.indexOf("acp");
   if (i === -1) return acpArgs;
   return [...acpArgs.slice(0, i), "--workspace", workspaceDir, ...acpArgs.slice(i)];
+}
+
+/** Insert CLI flags before the `acp` subcommand (same place as --workspace). */
+function acpArgsWithPreFlags(acpArgs: string[], flags: string[]): string[] {
+  if (!flags.length) return acpArgs;
+  const i = acpArgs.indexOf("acp");
+  if (i === -1) return acpArgs;
+  return [...acpArgs.slice(0, i), ...flags, ...acpArgs.slice(i)];
 }
 
 function extractModelFromCmdArgs(cmdArgs: string[]): string | undefined {
@@ -68,6 +102,11 @@ function acpInvocation(
   const model = extractModelFromCmdArgs(cmdArgs);
   const mode = extractModeFromCmdArgs(cmdArgs);
   let args = acpArgsWithWorkspace(config.acpArgs, workspaceDir);
+  // Non-ACP path already passes these via buildAgentFixedArgs; ACP previously ignored FORCE.
+  const preFlags: string[] = [];
+  if (config.force) preFlags.push("--force");
+  if (effectiveChatOnly) preFlags.push("--trust");
+  args = acpArgsWithPreFlags(args, preFlags);
   args = model ? acpArgsWithModel(args, model) : args;
   args = acpArgsWithMode(args, mode);
   const env = { ...config.acpEnv };
@@ -90,6 +129,7 @@ export function runAgentSync(
   signal?: AbortSignal,
   modelDisplayName?: string,
 ): Promise<AgentRunResult> {
+  ensureAgentProjectDir(workspaceDir, configDir);
   if (config.useAcp && typeof stdinPrompt === "string") {
     const invocation = acpInvocation(
       config,
@@ -160,6 +200,7 @@ export function runAgentStream(
   signal?: AbortSignal,
   modelDisplayName?: string,
 ): Promise<{ code: number; stderr: string }> {
+  ensureAgentProjectDir(workspaceDir, configDir);
   if (config.useAcp && typeof stdinPrompt === "string") {
     const invocation = acpInvocation(
       config,
@@ -240,6 +281,7 @@ export async function startAgentToolSession(opts: {
   if (!opts.config.useAcp) {
     throw new Error("Structured tool passthrough requires ACP mode");
   }
+  ensureAgentProjectDir(opts.workspaceDir, opts.configDir);
   const invocation = acpInvocation(
     opts.config,
     opts.workspaceDir,


### PR DESCRIPTION
## Summary
- Pre-create `CURSOR_CONFIG_DIR/projects/<slug>` before agent spawn so chat-only + `CURSOR_CONFIG_DIRS` does not crash on `worker.log` ENOENT (common on Windows temp workspaces).
- Pass `--force` / `--trust` on ACP argv the same way `buildAgentFixedArgs` does for `--print` (ACP previously ignored `CURSOR_BRIDGE_FORCE` / chat-only trust).
- Expand CLI model ids (`cursor-*-high`, `-fast`, `auto`) onto ACP catalog base ids under `strictModel`, and allow `auto` when it resolves to `default[]`.

## Test plan
- [x] `npm test` — new agent-runner / acp-client cases pass (2 unrelated Windows path/flake failures remain on this machine)
- [ ] With `CURSOR_BRIDGE_USE_ACP=true`, `CURSOR_BRIDGE_CHAT_ONLY_WORKSPACE=true`, `CURSOR_BRIDGE_FORCE=true`, and `CURSOR_CONFIG_DIRS=~/.cursor`, call `/v1/responses` with `model: "cursor-grok-4.5-high"` and confirm completed response
- [ ] Confirm agent no longer exits 1 on missing `projects/<slug>/worker.log`
- [ ] Confirm `auto` under strict ACP no longer throws when catalog has no `auto` row


Made with [Cursor](https://cursor.com)